### PR TITLE
Add Korean translations for module docs

### DIFF
--- a/Docs/kr/Modules/Achievements.md
+++ b/Docs/kr/Modules/Achievements.md
@@ -1,1 +1,305 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Achievements
+
+## 설명
+플레이어의 업적을 생성, 추적 및 잠금 해제하기위한 성취 모듈.진행 상황을 유지하기 위해 사용자 프로파일과 통합됩니다.
+
+## AchievementsModule
+
+성취 모듈의 주요 클래스.
+
+### 설정 :
+```csharp
+[Header("Permission")]
+[SerializeField] protected bool clientCanUpdateProgress = false;
+
+[Header("Settings")]
+[SerializeField] protected AchievementsDatabase achievementsDatabase;
+```
+
+### 종속성 :
+모듈에는 다음이 필요합니다.
+- 인증 - 사용자 인증을 위해
+- 프로파일 모듈 - 업적의 진행을 보존합니다
+
+## 성과 데이터베이스를 만듭니다
+
+### AchievementsDatabase:
+```csharp
+// Создание ScriptableObject с достижениями
+[CreateAssetMenu(menuName = "Master Server Toolkit/Achievements Database")]
+public class AchievementsDatabase : ScriptableObject
+{
+    [SerializeField] private List<AchievementData> achievements = new List<AchievementData>();
+    
+    public IReadOnlyCollection<AchievementData> Achievements => achievements;
+}
+```
+
+### 업적 정의 :
+```csharp
+// Создание в Unity Editor
+var database = ScriptableObject.CreateInstance<AchievementsDatabase>();
+
+// Добавление достижений
+database.Add(new AchievementData
+{
+    Key = "first_victory",
+    Title = "First Victory",
+    Description = "Win your first match",
+    Type = AchievementType.Normal,
+    MaxProgress = 1,
+    Unlockable = true
+});
+
+database.Add(new AchievementData
+{
+    Key = "win_streak",
+    Title = "Win Streak",
+    Description = "Win 10 matches in a row",
+    Type = AchievementType.Incremental,
+    MaxProgress = 10,
+    Unlockable = true
+});
+
+// Сохранение базы достижений
+AssetDatabase.CreateAsset(database, "Assets/Resources/AchievementsDatabase.asset");
+AssetDatabase.SaveAssets();
+```
+
+## 업적 유형
+
+### AchievementType:
+```csharp
+public enum AchievementType
+{
+    Normal,         // Обычное достижение (0/1)
+    Incremental,    // Постепенное достижение (0/N)
+    Infinite        // Бесконечное достижение (трекинг без разблокировки)
+}
+```
+
+### 성취 데이터 구조 :
+```csharp
+[Serializable]
+public class AchievementData
+{
+    public string Key;
+    public string Title;
+    public string Description;
+    public AchievementType Type;
+    public int MaxProgress;
+    public bool Unlockable;
+    public Sprite Icon;
+    public AchievementExtraData[] ResultCommands;
+    
+    [Serializable]
+    public class AchievementExtraData
+    {
+        public string CommandKey;
+        public string[] CommandValues;
+    }
+}
+```
+
+## 업적 진행 상황 업데이트
+
+서버에서 ### :
+```csharp
+// Получить модуль
+var achievementsModule = Mst.Server.Modules.GetModule<AchievementsModule>();
+
+// Обновить прогресс достижения
+void UpdateAchievement(string userId, string achievementKey, int progress)
+{
+    var packet = new UpdateAchievementProgressPacket
+    {
+        userId = userId, 
+        key = achievementKey,
+        progress = progress
+    };
+    
+    // Отправить пакет обновления
+    Mst.Server.SendMessage(MstOpCodes.ServerUpdateAchievementProgress, packet);
+}
+
+// Пример использования
+UpdateAchievement(user.UserId, "first_victory", 1);
+```
+
+클라이언트 측의 ### (허용 된 경우) :
+```csharp
+// Клиентский запрос на обновление прогресса
+void UpdateAchievement(string achievementKey, int progress)
+{
+    var packet = new UpdateAchievementProgressPacket
+    {
+        key = achievementKey,
+        progress = progress
+    };
+    
+    Mst.Client.Connection.SendMessage(MstOpCodes.ClientUpdateAchievementProgress, packet, (status, response) =>
+    {
+        if (status == ResponseStatus.Success)
+        {
+            Debug.Log($"Achievement progress updated for {achievementKey}");
+        }
+    });
+}
+```
+
+## 프로파일과 통합
+
+성과는 프로파일 속성을 통해 사용자 프로파일과 자동으로 동기화됩니다.
+
+```csharp
+// Регистрация свойства достижений в ProfilesModule
+profilesModule.RegisterProperty(ProfilePropertyOpCodes.achievements, null, () =>
+{
+    return new ObservableAchievements();
+});
+
+// Получение достижений из профиля
+void GetAchievements(ObservableServerProfile profile)
+{
+    if (profile.TryGet(ProfilePropertyOpCodes.achievements, out ObservableAchievements achievements))
+    {
+        // Список всех достижений пользователя
+        var allAchievements = achievements.GetAll();
+        
+        // Проверка разблокировано ли достижение
+        bool isUnlocked = achievements.IsUnlocked("first_victory");
+        
+        // Получить прогресс достижения
+        int progress = achievements.GetProgress("win_streak");
+    }
+}
+```
+
+## 추적 이벤트 잠금 해제
+
+고객의 이벤트에 대한 ### 구독 :
+```csharp
+// В клиентском классе
+private void Start()
+{
+    Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.ClientAchievementUnlocked, OnAchievementUnlocked);
+}
+
+private void OnAchievementUnlocked(IIncomingMessage message)
+{
+    string achievementKey = message.AsString();
+    Debug.Log($"Achievement unlocked: {achievementKey}");
+    
+    // Показать интерфейс разблокировки достижения
+    ShowAchievementUnlockedUI(achievementKey);
+}
+```
+
+## 성과에 대한 상 설정
+
+모듈을 사용하면 잠금 해제시 실행될 명령을 구성 할 수 있습니다.
+
+```csharp
+// Настройка ResultCommands в достижении
+var achievement = new AchievementData
+{
+    Key = "100_matches_played",
+    Title = "Veteran",
+    Description = "Play 100 matches",
+    Type = AchievementType.Incremental,
+    MaxProgress = 100,
+    Unlockable = true,
+    
+    // Команды для выполнения при разблокировке
+    ResultCommands = new[]
+    {
+        new AchievementExtraData
+        {
+            CommandKey = "add_currency",
+            CommandValues = new[] { "gold", "100" }
+        },
+        new AchievementExtraData
+        {
+            CommandKey = "unlock_avatar",
+            CommandValues = new[] { "veteran_avatar" }
+        }
+    }
+};
+```
+
+### 팀 처리 :
+```csharp
+// Расширение модуля для обработки команд
+public class MyAchievementsModule : AchievementsModule
+{
+    protected override void OnAchievementResultCommand(IUserPeerExtension user, string key, AchievementExtraData[] resultCommands)
+    {
+        foreach (var command in resultCommands)
+        {
+            switch (command.CommandKey)
+            {
+                case "add_currency":
+                    AddCurrency(user, command.CommandValues[0], int.Parse(command.CommandValues[1]));
+                    break;
+                    
+                case "unlock_avatar":
+                    UnlockAvatar(user, command.CommandValues[0]);
+                    break;
+                
+                // Другие команды
+                default:
+                    logger.Error($"Unknown achievement command: {command.CommandKey}");
+                    break;
+            }
+        }
+    }
+    
+    private void AddCurrency(IUserPeerExtension user, string currencyType, int amount)
+    {
+        // Добавление валюты игроку
+    }
+    
+    private void UnlockAvatar(IUserPeerExtension user, string avatarId)
+    {
+        // Разблокировка аватара игроку
+    }
+}
+```
+
+## 클라이언트 랩
+
+### AchievementsModuleClient:
+```csharp
+// Пример использования
+var client = Mst.Client.Modules.GetModule<AchievementsModuleClient>();
+
+// Получение списка достижений
+var achievements = client.GetAchievements();
+
+// Отображение интерфейса
+void ShowAchievementsUI()
+{
+    foreach (var achievement in achievements)
+    {
+        // Создать элемент интерфейса для достижения
+        var item = Instantiate(achievementItemPrefab, container);
+        
+        // Заполнить данными
+        item.SetTitle(achievement.Title);
+        item.SetDescription(achievement.Description);
+        item.SetIcon(achievement.Icon);
+        item.SetProgress(achievement.CurrentProgress, achievement.MaxProgress);
+        item.SetUnlocked(achievement.IsUnlocked);
+    }
+}
+```
+
+## 모범 사례
+
+1. ** 각 업적에 대해 고유 키 **를 사용하십시오
+2. ** 별도의 단일 및 부수적 ** 업적
+3. ** 속임수를 방지하기 위해 서버 측에서 확인을 소개합니다.
+4. ** 서버에서 상을 수상한 논리를 수행 **
+5. ** 클라이언트에 대한 성과를 캐싱 ** 빠른 액세스
+6. ** 비슷한 업적 잠금 해제 ** 자동으로 (예를 들어, "10 명의 몬스터 킬"을 자동으로 잠금 해제 "5 몬스터 킬")
+7. ** 게임 플레이를 평가하기 위해 성취하여 분석 수집 **

--- a/Docs/kr/Modules/AnalyticsModule.md
+++ b/Docs/kr/Modules/AnalyticsModule.md
@@ -1,1 +1,237 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Analytics
+
+## 설명
+사용자 쿼리 및 데이터 여과를 지원하는 게임 이벤트 및 메트릭의 수집, 저장 및 분석 모듈.
+
+## 주요 구성 요소
+
+### AnalyticsModule (서버)
+```csharp
+// Настройки
+[SerializeField] protected float saveDebounceTime = 5f; // Задержка перед сохранением в БД
+[SerializeField] protected bool useAnalytics = true;    // Включить/выключить аналитику
+[SerializeField] protected DatabaseAccessorFactory databaseAccessorFactory; // Фабрика базы данных
+```
+
+### AnalyticsModuleClient (클라이언트)
+```csharp
+// Отправка события (единоразовое)
+void SendEvent(string key, string category, Dictionary<string, string> data);
+
+// Отправка события сессии (только один раз за сессию)
+void SendSessionEvent(string key, string category, Dictionary<string, string> data);
+```
+
+## 사건의 구조
+
+### AnalyticsDataInfoPacket
+```csharp
+public class AnalyticsDataInfoPacket : IAnalyticsInfoData
+{
+    public string Id { get; set; }                       // Уникальный ID события
+    public string UserId { get; set; }                   // ID пользователя
+    public string Key { get; set; }                      // Ключ события
+    public string Category { get; set; }                 // Категория события
+    public DateTime Timestamp { get; set; }              // Время события
+    public Dictionary<string, string> Data { get; set; } // Данные события
+    public bool IsSessionEvent { get; set; }             // Событие сессии
+}
+```
+
+## 사용의 예
+
+### 클라이언트로부터 이벤트 보내기
+```csharp
+// Получение клиента
+var analytics = Mst.Client.Analytics;
+
+// Простое событие игры
+var data = new Dictionary<string, string>
+{
+    { "level", "2" },
+    { "difficulty", "normal" },
+    { "time", "125.5" }
+};
+
+analytics.SendEvent("level_completed", "gameplay", data);
+
+// Событие сессии (отправляется только один раз за сессию)
+var sessionData = new Dictionary<string, string>
+{
+    { "device", SystemInfo.deviceModel },
+    { "os", SystemInfo.operatingSystem },
+    { "screen_resolution", $"{Screen.width}x{Screen.height}" }
+};
+
+analytics.SendSessionEvent("session_start", "system", sessionData);
+```
+
+### 게임 동작 추적을위한 시스템
+```csharp
+public class AnalyticsTracker : MonoBehaviour
+{
+    // Отслеживание предметов
+    public void TrackItemAcquired(string itemId, string source)
+    {
+        var data = new Dictionary<string, string>
+        {
+            { "item_id", itemId },
+            { "source", source },
+            { "player_level", PlayerStats.Level.ToString() }
+        };
+        
+        Mst.Client.Analytics.SendEvent("item_acquired", "economy", data);
+    }
+    
+    // Отслеживание боевой системы
+    public void TrackEnemyDefeated(string enemyType, string weaponUsed, int timeToKill)
+    {
+        var data = new Dictionary<string, string>
+        {
+            { "enemy_type", enemyType },
+            { "weapon", weaponUsed },
+            { "time_to_kill", timeToKill.ToString() },
+            { "player_health", PlayerStats.Health.ToString() }
+        };
+        
+        Mst.Client.Analytics.SendEvent("enemy_defeated", "combat", data);
+    }
+    
+    // Отслеживание покупок
+    public void TrackPurchase(string productId, float price, string currency)
+    {
+        var data = new Dictionary<string, string>
+        {
+            { "product_id", productId },
+            { "price", price.ToString() },
+            { "currency", currency },
+            { "player_balance", PlayerStats.Balance.ToString() }
+        };
+        
+        Mst.Client.Analytics.SendEvent("purchase", "economy", data);
+    }
+}
+```
+
+### 데이터베이스 액세스 인터페이스 구현
+```csharp
+public class MongoAnalyticsAccessor : IAnalyticsDatabaseAccessor
+{
+    private MongoClient client;
+    private IMongoDatabase database;
+    private IMongoCollection<AnalyticsDataInfoPacket> eventsCollection;
+    
+    public void Initialize(string connectionString)
+    {
+        client = new MongoClient(connectionString);
+        database = client.GetDatabase("game_analytics");
+        eventsCollection = database.GetCollection<AnalyticsDataInfoPacket>("events");
+    }
+    
+    public async Task Insert(IEnumerable<IAnalyticsInfoData> eventsData)
+    {
+        var documents = eventsData.Cast<AnalyticsDataInfoPacket>().ToList();
+        await eventsCollection.InsertManyAsync(documents);
+    }
+    
+    public async Task<IEnumerable<IAnalyticsInfoData>> GetByKey(string eventKey, int size, int page)
+    {
+        var filter = Builders<AnalyticsDataInfoPacket>.Filter.Eq(e => e.Key, eventKey);
+        var options = new FindOptions<AnalyticsDataInfoPacket>
+        {
+            Limit = size,
+            Skip = page * size
+        };
+        
+        var cursor = await eventsCollection.FindAsync(filter, options);
+        return await cursor.ToListAsync();
+    }
+    
+    // Реализация других методов интерфейса...
+}
+```
+
+### 데이터베이스 등록
+```csharp
+public class AnalyticsDatabaseFactory : DatabaseAccessorFactory
+{
+    [SerializeField] private string connectionString = "mongodb://localhost:27017";
+    
+    public override void CreateAccessors()
+    {
+        var accessor = new MongoAnalyticsAccessor();
+        accessor.Initialize(connectionString);
+        
+        Mst.Server.DbAccessors.AddAccessor(accessor);
+    }
+}
+```
+
+## 서버의 데이터 쿼리
+
+```csharp
+// Получение модуля
+var analyticsModule = Mst.Server.Modules.GetModule<AnalyticsModule>();
+
+// Получение всех событий (с пагинацией)
+var allEvents = await analyticsModule.GetAll(100, 0); // 100 событий, страница 0
+
+// Получение событий по ключу
+var levelEvents = await analyticsModule.GetByKey("level_completed", 100, 0);
+
+// Получение событий пользователя
+var userEvents = await analyticsModule.GetByUserId(userId, 100, 0);
+
+// Получение событий в диапазоне дат
+var dateStart = DateTime.UtcNow.AddDays(-7);
+var dateEnd = DateTime.UtcNow;
+var weekEvents = await analyticsModule.GetByTimestampRange(dateStart, dateEnd, 1000, 0);
+
+// Получение событий с пользовательским запросом
+var customQuery = "{ $and: [ { 'Key': 'purchase' }, { 'Data.price': { $gt: '10' } } ] }";
+var expensivePurchases = await analyticsModule.GetWithQuery(customQuery, 100, 0);
+```
+
+## 웹 패널과 통합
+
+```csharp
+// Контроллер для веб-панели аналитики
+public class AnalyticsWebController : WebController
+{
+    private AnalyticsModule analyticsModule;
+    
+    public override void Initialize(WebServerModule server)
+    {
+        base.Initialize(server);
+        
+        analyticsModule = server.GetModule<AnalyticsModule>();
+        
+        // API маршруты
+        WebServer.RegisterGetHandler("api/analytics/events", GetEventsHandler, true);
+        WebServer.RegisterGetHandler("api/analytics/users", GetUsersHandler, true);
+        WebServer.RegisterGetHandler("api/analytics/dashboard", GetDashboardHandler, true);
+    }
+    
+    private async Task<IHttpResult> GetEventsHandler(HttpListenerRequest request)
+    {
+        string eventType = request.QueryString["type"];
+        int size = int.Parse(request.QueryString["size"] ?? "100");
+        int page = int.Parse(request.QueryString["page"] ?? "0");
+        
+        var events = await analyticsModule.GetByKey(eventType, size, page);
+        
+        return new JsonResult(events);
+    }
+    
+    // Другие обработчики...
+}
+```
+
+## 모범 사례
+
+1. ** 이벤트 패키지 처리에 Debows ** 사용 **
+2. ** 카테고리 별 그룹 이벤트 **보다 편리한 분석을 위해
+3. ** 수집 된 데이터 금액 제한 ** - 필요한 정보 만 수집하십시오.
+4. ** 이벤트 이벤트 문서 ** 일관성을 보장합니다.
+5. ** 데이터를 정기적으로 분석하여 추세를 식별합니다.
+6. ** 이벤트에 고유 식별자 ** 사용하여 복제를 제거하십시오.

--- a/Docs/kr/Modules/Authentication.md
+++ b/Docs/kr/Modules/Authentication.md
@@ -1,1 +1,263 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Authentication
+
+## 설명
+등록, 시스템 입력, 암호 복원 및 사용자 관리를위한 인증 모듈.
+
+## AuthModule
+
+인증 모듈의 주요 클래스.
+
+### 설정 :
+```csharp
+[Header("Settings")]
+[SerializeField] private int usernameMinChars = 4;
+[SerializeField] private int usernameMaxChars = 12;
+[SerializeField] private int userPasswordMinChars = 8;
+[SerializeField] private bool emailConfirmRequired = true;
+
+[Header("Guest Settings")]
+[SerializeField] private bool allowGuestLogin = true;
+[SerializeField] private string guestPrefix = "user_";
+
+[Header("Security")]
+[SerializeField] private string tokenSecret = "your-secret-key";
+[SerializeField] private int tokenExpiresInDays = 7;
+```
+
+### 인증 유형 :
+
+#### 1. 이름과 비밀번호로 :
+```csharp
+// Клиент отправляет
+var credentials = new MstProperties();
+credentials.Set(MstDictKeys.USER_NAME, "playerName");
+credentials.Set(MstDictKeys.USER_PASSWORD, "password123");
+credentials.Set(MstDictKeys.USER_DEVICE_ID, "device123");
+credentials.Set(MstDictKeys.USER_DEVICE_NAME, "iPhone 12");
+
+// Шифрование и отправка
+var encryptedData = Mst.Security.EncryptAES(credentials.ToBytes(), aesKey);
+Mst.Client.Connection.SendMessage(MstOpCodes.SignIn, encryptedData);
+```
+
+### 2. 이메일로 :
+```csharp
+// Отправляет пароль на email
+var credentials = new MstProperties();
+credentials.Set(MstDictKeys.USER_EMAIL, "player@game.com");
+Mst.Client.Connection.SendMessage(MstOpCodes.SignIn, credentials);
+```
+
+#### 3. 토큰의 경우 :
+```csharp
+// Автоматический вход
+var credentials = new MstProperties();
+credentials.Set(MstDictKeys.USER_AUTH_TOKEN, savedToken);
+Mst.Client.Connection.SendMessage(MstOpCodes.SignIn, credentials);
+```
+
+### 4. 게스트 입력 :
+```csharp
+var credentials = new MstProperties();
+credentials.Set(MstDictKeys.USER_IS_GUEST, true);
+credentials.Set(MstDictKeys.USER_DEVICE_ID, "device123");
+Mst.Client.Connection.SendMessage(MstOpCodes.SignIn, credentials);
+```
+
+## 등록
+
+```csharp
+// Создание аккаунта
+var credentials = new MstProperties();
+credentials.Set(MstDictKeys.USER_NAME, "newPlayer");
+credentials.Set(MstDictKeys.USER_PASSWORD, "securePassword");
+credentials.Set(MstDictKeys.USER_EMAIL, "new@player.com");
+
+// Шифрование
+var encrypted = Mst.Security.EncryptAES(credentials.ToBytes(), aesKey);
+Mst.Client.Connection.SendMessage(MstOpCodes.SignUp, encrypted);
+```
+
+## 사용자 관리
+
+### poglot 사용자와 함께 작업 :
+```csharp
+// Получить пользователя
+var user = authModule.GetLoggedInUserByUsername("playerName");
+var user = authModule.GetLoggedInUserById("userId");
+var user = authModule.GetLoggedInUserByEmail("email@game.com");
+
+// Проверить залогинен ли
+bool isOnline = authModule.IsUserLoggedInByUsername("playerName");
+
+// Получить всех онлайн
+var allOnline = authModule.LoggedInUsers;
+
+// Разлогинить
+authModule.SignOut("playerName");
+authModule.SignOut(userExtension);
+```
+
+### 이벤트 :
+```csharp
+// Подписка на события
+authModule.OnUserLoggedInEvent += (user) => {
+    Debug.Log($"User {user.Username} logged in");
+};
+
+authModule.OnUserLoggedOutEvent += (user) => {
+    Debug.Log($"User {user.Username} logged out");
+};
+
+authModule.OnUserRegisteredEvent += (peer, account) => {
+    Debug.Log($"New user registered: {account.Username}");
+};
+```
+
+## 비밀번호 복구
+
+### 코드 요청 :
+```csharp
+// Клиент запрашивает код
+Mst.Connection.SendMessage(MstOpCodes.GetPasswordResetCode, "email@game.com");
+
+// Сервер отправляет код на email
+```
+
+## 비밀번호 변경 :
+```csharp
+var data = new MstProperties();
+data.Set(MstDictKeys.RESET_PASSWORD_EMAIL, "email@game.com");
+data.Set(MstDictKeys.RESET_PASSWORD_CODE, "123456");
+data.Set(MstDictKeys.RESET_PASSWORD, "newPassword");
+
+Mst.Connection.SendMessage(MstOpCodes.ChangePassword, data);
+```
+
+## 확인 이메일
+
+```csharp
+// Запрос кода подтверждения
+Mst.Connection.SendMessage(MstOpCodes.GetEmailConfirmationCode);
+
+// Подтверждение email
+Mst.Connection.SendMessage(MstOpCodes.ConfirmEmail, "confirmationCode");
+```
+
+## 추가 속성
+
+```csharp
+// Привязка дополнительных данных
+var extraProps = new MstProperties();
+extraProps.Set("playerLevel", 10);
+extraProps.Set("gameClass", "warrior");
+
+Mst.Connection.SendMessage(MstOpCodes.BindExtraProperties, extraProps);
+```
+
+## 데이터베이스 설정
+
+```csharp
+// Реализация IAccountsDatabaseAccessor
+public class MyDatabaseAccessor : IAccountsDatabaseAccessor
+{
+    public async Task<IAccountInfoData> GetAccountByUsernameAsync(string username)
+    {
+        // Получение аккаунта из БД
+    }
+    
+    public async Task InsertAccountAsync(IAccountInfoData account)
+    {
+        // Сохранение нового аккаунта
+    }
+    
+    public async Task UpdateAccountAsync(IAccountInfoData account)
+    {
+        // Обновление аккаунта
+    }
+}
+
+// Создание фабрики
+public class DatabaseFactory : DatabaseAccessorFactory
+{
+    public override void CreateAccessors()
+    {
+        var accessor = new MyDatabaseAccessor();
+        Mst.Server.DbAccessors.AddAccessor(accessor);
+    }
+}
+```
+
+## 액세스 권한 검증
+
+```csharp
+// Получение информации о пире
+Mst.Connection.SendMessage(MstOpCodes.GetAccountInfoByPeer, peerId);
+Mst.Connection.SendMessage(MstOpCodes.GetAccountInfoByUsername, "playerName");
+
+// Требует минимальный уровень прав
+authModule.getPeerDataPermissionsLevel = 10;
+```
+
+## 유효성 검사의 Castomization
+
+```csharp
+// Переопределение в наследнике AuthModule
+protected override bool IsUsernameValid(string username)
+{
+    if (!base.IsUsernameValid(username))
+        return false;
+    
+    // Дополнительные проверки
+    if (username.Contains("admin"))
+        return false;
+    
+    return true;
+}
+
+protected override bool IsPasswordValid(string password)
+{
+    if (!base.IsPasswordValid(password))
+        return false;
+    
+    // Проверка на сложность
+    bool hasUpper = password.Any(char.IsUpper);
+    bool hasNumber = password.Any(char.IsDigit);
+    
+    return hasUpper && hasNumber;
+}
+```
+
+## 이메일과 통합
+
+```csharp
+// Настройка mailer компонента
+[SerializeField] protected Mailer mailer;
+
+// Настройка Smtp (в SmtpMailer)
+smtpHost = "smtp.gmail.com";
+smtpPort = 587;
+smtpUsername = "yourgame@gmail.com";
+smtpPassword = "app-password";
+mailFrom = "noreply@yourgame.com";
+```
+
+## 명령 줄 인수
+
+```bash
+# Токен настройки
+./Server.exe -tokenSecret mysecret -tokenExpires 30
+
+# Настройка issuer/audience
+./Server.exe -tokenIssuer http://mygame.com -tokenAudience http://mygame.com/users
+```
+
+## 모범 사례
+
+1. ** 보내기 전에 항상 암호를 암호화하십시오 **
+2. ** 저자를 위해 토큰 사용 **
+3. ** 데이터베이스에 기밀 데이터 저장 **
+4. ** 비밀번호 복원을 위해 이메일을 설정 **
+5. ** 인구 조사를 사용하여 검열 이름을 확인하십시오 **
+6. ** 입력 시도 수 제한 **
+7. ** 생산에 HTTPS 사용 **

--- a/Docs/kr/Modules/Censor.md
+++ b/Docs/kr/Modules/Censor.md
@@ -1,1 +1,233 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Censor
+
+## 설명
+외설적 인 어휘 또는 모욕과 같은 원치 않는 콘텐츠를 필터링하기위한 검열 모듈.플레이어 간의 안전한 의사 소통을 제공합니다.
+
+## CensorModule
+
+검열 모듈의 주요 클래스.
+
+### 설정 :
+```csharp
+[Header("Settings")]
+[SerializeField] private TextAsset[] wordsLists;
+[SerializeField, TextArea(5, 10)] private string matchPattern = @"\b{0}\b";
+```
+
+## H 초기화 :
+```csharp
+// Добавление модуля на сцену
+var censorModule = gameObject.AddComponent<CensorModule>();
+
+// Настройка списков запрещенных слов
+public TextAsset[] wordsLists;
+wordsLists = new TextAsset[] { forbiddenWordsAsset };
+```
+
+### 사전 형식 :
+사전은 쉼표로 분리 된 단어가 금지 된 텍스트 파일입니다.
+```
+bad,words,list,here,separated,by,commas
+```
+
+## 코드에서 사용하십시오
+
+## 텍스트 클래싱 :
+```csharp
+// Получение экземпляра модуля
+var censorModule = Mst.Server.Modules.GetModule<CensorModule>();
+
+// Проверка текста на наличие запрещенных слов
+bool hasBadWord = censorModule.HasCensoredWord("Text to check");
+
+if (hasBadWord)
+{
+    // Текст содержит запрещенные слова
+    Debug.Log("Text contains censored words");
+}
+else
+{
+    // Текст безопасен
+    Debug.Log("Text is clean");
+}
+```
+
+### 채팅 통합 :
+```csharp
+// В обработчике сообщений чата
+void HandleChatMessage(string message, IPeer sender)
+{
+    var censorModule = Mst.Server.Modules.GetModule<CensorModule>();
+    
+    if (censorModule.HasCensoredWord(message))
+    {
+        // Отклонить сообщение
+        sender.SendMessage(MstOpCodes.MessageRejected, "Message contains forbidden words");
+        return;
+    }
+    
+    // Отправить сообщение всем пользователям
+    BroadcastMessage(message);
+}
+```
+
+## 사용자의 클래스 이름 :
+```csharp
+// При регистрации в AuthModule
+protected override bool IsUsernameValid(string username)
+{
+    if (!base.IsUsernameValid(username))
+        return false;
+    
+    var censorModule = Mst.Server.Modules.GetModule<CensorModule>();
+    
+    // Проверка имени на запрещенные слова
+    if (censorModule.HasCensoredWord(username))
+        return false;
+    
+    return true;
+}
+```
+
+## Patterna Patterna 설정
+
+`matchpattern '매개 변수는 금지 된 단어를 확인하는 방법을 결정합니다.
+
+```csharp
+// По умолчанию: Целые слова (используя границы слов)
+matchPattern = @"\b{0}\b";
+
+// Более строгая проверка: включая частичные совпадения
+matchPattern = @"{0}";
+
+// С разделителями: проверяет только слова, разделенные пробелами
+matchPattern = @"(\s|^){0}(\s|$)";
+```
+
+## 모듈의 확장
+
+Censormodule에 상속인을 만들어 기본 기능을 확장 할 수 있습니다.
+
+```csharp
+public class EnhancedCensorModule : CensorModule
+{
+    [SerializeField] private bool useRegexPatterns = false;
+    [SerializeField] private TextAsset regexPatterns;
+    
+    private List<Regex> patterns = new List<Regex>();
+    
+    protected override void ParseTextFiles()
+    {
+        base.ParseTextFiles();
+        
+        // Загрузка дополнительных регулярных выражений
+        if (useRegexPatterns && regexPatterns != null)
+        {
+            var patternLines = regexPatterns.text.Split('\n');
+            foreach (var pattern in patternLines)
+            {
+                if (!string.IsNullOrEmpty(pattern))
+                {
+                    patterns.Add(new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled));
+                }
+            }
+        }
+    }
+    
+    public override bool HasCensoredWord(string text)
+    {
+        // Проверка базовым методом
+        if (base.HasCensoredWord(text))
+            return true;
+        
+        // Проверка с помощью регулярных выражений
+        foreach (var regex in patterns)
+        {
+            if (regex.IsMatch(text))
+                return true;
+        }
+        
+        return false;
+    }
+    
+    // Дополнительный метод для получения замаскированного текста
+    public string GetCensoredText(string text, char maskChar = '*')
+    {
+        string result = text;
+        
+        // Замена запрещенных слов маской
+        foreach (var word in censoredWords)
+        {
+            string pattern = string.Format(matchPattern, Regex.Escape(word));
+            string replacement = new string(maskChar, word.Length);
+            result = Regex.Replace(result, pattern, replacement, RegexOptions.IgnoreCase);
+        }
+        
+        return result;
+    }
+}
+```
+
+## 모범 사례
+
+1. ** 정기적으로 사전을 업데이트 ** 금지 된 단어
+2. ** 허위 작품을 피하려면 단어의 경계를 사용하십시오 (`\ b {0} \ b`)
+3. ** 자동 게시 메시지를 위해 채팅 시스템과 통합 **
+4. ** 텍스트 전환을 추가 ** 간단한 속임수를 우회하기 전에 확인하기 전에 (예 : "B@D w0rd")
+5. ** 국제 프로젝트 용 다국어 지원 ** 켜기 **
+6. ** 컨텍스트를 고려하십시오 ** 필터링 중에 - 어떤 단어는 한 컨텍스트에서는 정상이지만 다른 단어에서는 바람직하지 않습니다.
+7. ** 다른 지역의 경우 현지 사전 **를 사용하십시오
+
+## 통합의 예
+
+### 자동 경고 시스템 :
+```csharp
+public class ChatFilterSystem : MonoBehaviour
+{
+    [SerializeField] private int maxViolations = 3;
+    private Dictionary<string, int> violations = new Dictionary<string, int>();
+    
+    public void CheckMessage(string username, string message)
+    {
+        var censorModule = Mst.Server.Modules.GetModule<CensorModule>();
+        
+        if (censorModule.HasCensoredWord(message))
+        {
+            if (!violations.ContainsKey(username))
+                violations[username] = 0;
+                
+            violations[username]++;
+            
+            if (violations[username] >= maxViolations)
+            {
+                // Временный бан пользователя
+                BanUser(username, TimeSpan.FromMinutes(10));
+            }
+        }
+    }
+}
+```
+
+### 사용자 콘텐츠와 통합 :
+```csharp
+// Проверка пользовательских названий
+public bool ValidateUserContent(string text)
+{
+    var censorModule = Mst.Server.Modules.GetModule<CensorModule>();
+    return !censorModule.HasCensoredWord(text);
+}
+
+// Использование при создании предметов, кланов и т.д.
+public bool CreateClan(string clanName, string clanTag)
+{
+    if (!ValidateUserContent(clanName) || !ValidateUserContent(clanTag))
+    {
+        return false;
+    }
+    
+    // Создание клана
+    // ...
+    
+    return true;
+}
+```

--- a/Docs/kr/Modules/Chat.md
+++ b/Docs/kr/Modules/Chat.md
@@ -1,1 +1,278 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Chat
+
+## 설명
+채널, 비공개 메시지 및 음란 한 단어 검사를 지원하는 채팅 시스템을 작성하기위한 모듈.
+
+## ChatModule
+
+채팅 제어를위한 메인 클래스.
+
+### 설정 :
+```csharp
+[Header("General Settings")]
+[SerializeField] protected bool useAuthModule = true;
+[SerializeField] protected bool useCensorModule = true;
+[SerializeField] protected bool allowUsernamePicking = true;
+
+[SerializeField] protected bool setFirstChannelAsLocal = true;
+[SerializeField] protected bool setLastChannelAsLocal = true;
+
+[SerializeField] protected int minChannelNameLength = 5;
+[SerializeField] protected int maxChannelNameLength = 25;
+```
+
+## 채널에서 작업하십시오
+
+### 생성/채널 :
+```csharp
+// Получить или создать канал
+var channel = chatModule.GetOrCreateChannel("general");
+
+// Проверка на запрещенные слова
+var channel = chatModule.GetOrCreateChannel("badword", true); // игнорировать проверку
+```
+
+### 채널 연결 :
+```csharp
+// Отправка запроса на сервер
+Mst.Client.Connection.SendMessage(MstOpCodes.JoinChannel, "general");
+
+// Получение текущих каналов
+Mst.Client.Connection.SendMessage(MstOpCodes.GetCurrentChannels);
+```
+
+### 채널 관리 :
+```csharp
+// Покинуть канал
+Mst.Client.Connection.SendMessage(MstOpCodes.LeaveChannel, "general");
+
+// Установить канал по умолчанию
+Mst.Client.Connection.SendMessage(MstOpCodes.SetDefaultChannel, "global");
+
+// Получить список пользователей в канале
+Mst.Client.Connection.SendMessage(MstOpCodes.GetUsersInChannel, "general");
+```
+
+## 게시물 보내기
+
+### 게시물 유형 :
+```csharp
+public enum ChatMessageType : byte
+{
+    ChannelMessage, // Сообщение в канал
+    PrivateMessage  // Приватное сообщение
+}
+```
+
+### 게시물 보내기 :
+```csharp
+// Сообщение в канал
+var channelMsg = new ChatMessagePacket
+{
+    MessageType = ChatMessageType.ChannelMessage,
+    Receiver = "general",  // имя канала
+    Message = "Hello everyone!"
+};
+Mst.Client.Connection.SendMessage(MstOpCodes.ChatMessage, channelMsg);
+
+// Сообщение в личный канал (без указания получателя)
+var localMsg = new ChatMessagePacket
+{
+    MessageType = ChatMessageType.ChannelMessage,
+    Receiver = null, // отправится в DefaultChannel
+    Message = "Hello local channel!"
+};
+
+// Приватное сообщение
+var privateMsg = new ChatMessagePacket
+{
+    MessageType = ChatMessageType.PrivateMessage,
+    Receiver = "username",  // имя пользователя
+    Message = "Hello privately!"
+};
+```
+
+## 사용자 관리
+
+### 사용자 이름 설정 :
+```csharp
+// Если allowUsernamePicking = true
+Mst.Client.Connection.SendMessage(MstOpCodes.PickUsername, "myUsername");
+```
+
+### ChatuserPeerestension과 함께 작업 :
+```csharp
+// Получить расширение пользователя
+var chatUser = peer.GetExtension<ChatUserPeerExtension>();
+
+// Изменить имя пользователя
+chatModule.ChangeUsername(peer, "newUsername", true); // сохранить каналы
+
+// Доступ к каналам пользователя
+var channels = chatUser.CurrentChannels;
+var defaultChannel = chatUser.DefaultChannel;
+```
+
+## 다른 모듈과의 통합
+
+### AuthModule과 통합 :
+```csharp
+// При useAuthModule = true
+authModule.OnUserLoggedInEvent += OnUserLoggedInEventHandler;
+authModule.OnUserLoggedOutEvent += OnUserLoggedOutEventHandler;
+
+// Автоматическое создание ChatUser при входе
+```
+
+### 인구 조사와 통합 :
+```csharp
+// При useCensorModule = true
+// Автоматическая проверка сообщений на нецензурные слова
+// Замена запрещенного сообщения на предупреждение
+```
+
+## castomization
+
+### 게시물이 내려다 보입니다.
+```csharp
+protected override bool TryHandleChatMessage(ChatMessagePacket chatMessage, ChatUserPeerExtension sender, IIncomingMessage message)
+{
+    // Кастомная логика обработки
+    if (chatMessage.Message.StartsWith("/"))
+    {
+        HandleCommand(chatMessage);
+        return true;
+    }
+    
+    return base.TryHandleChatMessage(chatMessage, sender, message);
+}
+```
+
+## 사용자 정의 사용자 생성 :
+```csharp
+protected override ChatUserPeerExtension CreateChatUser(IPeer peer, string username)
+{
+    // Создание расширенного пользователя
+    return new MyChatUserExtension(peer, username);
+}
+```
+
+## 클라이언트 코드.
+
+### 이벤트 구독 :
+```csharp
+// Подключение к чат-модулю
+Mst.Client.Chat.Connection = connection;
+
+// События
+Mst.Client.Chat.OnMessageReceivedEvent += (message) => {
+    Debug.Log($"[{message.Sender}]: {message.Message}");
+};
+
+Mst.Client.Chat.OnLeftChannelEvent += (channel) => {
+    Debug.Log($"Left channel: {channel}");
+};
+
+Mst.Client.Chat.OnJoinedChannelEvent += (channel) => {
+    Debug.Log($"Joined channel: {channel}");
+};
+```
+
+### 고객에게서 보내기 :
+```csharp
+// В канал
+Mst.Client.Chat.SendToChannel("general", "Hello world!");
+
+// Приватное сообщение
+Mst.Client.Chat.SendToUser("username", "Secret message");
+
+// В локальный канал
+Mst.Client.Chat.SendToLocalChannel("Hello local!");
+```
+
+## 사용의 예
+
+## 게임 채팅 생성 :
+```csharp
+public class GameChatUI : MonoBehaviour
+{
+    [Header("UI")]
+    public InputField messageInput;
+    public Text chatLog;
+    public Dropdown channelDropdown;
+    
+    void Start()
+    {
+        // Присоединиться к общему каналу
+        Mst.Client.Chat.JoinChannel("general");
+        Mst.Client.Chat.SetDefaultChannel("general");
+        
+        // Событие получения сообщения
+        Mst.Client.Chat.OnMessageReceivedEvent += OnMessageReceived;
+        
+        // События каналов
+        Mst.Client.Chat.OnChannelUsersChanged += OnChannelUsersChanged;
+    }
+    
+    private void OnMessageReceived(ChatMessagePacket message)
+    {
+        string formattedMsg = $"{message.Sender}: {message.Message}\n";
+        chatLog.text += formattedMsg;
+    }
+    
+    public void SendMessage()
+    {
+        if (!string.IsNullOrEmpty(messageInput.text))
+        {
+            Mst.Client.Chat.SendToDefaultChannel(messageInput.text);
+            messageInput.text = "";
+        }
+    }
+}
+```
+
+### 채팅 팀 시스템 :
+```csharp
+protected override bool TryHandleChatMessage(ChatMessagePacket chatMessage, ChatUserPeerExtension sender, IIncomingMessage message)
+{
+    if (chatMessage.Message.StartsWith("/"))
+    {
+        var command = chatMessage.Message.Split(' ')[0].Substring(1);
+        var args = chatMessage.Message.Split(' ').Skip(1).ToArray();
+        
+        switch (command)
+        {
+            case "whisper":
+                if (args.Length >= 2)
+                {
+                    var targetUser = args[0];
+                    var privateMsg = string.Join(" ", args.Skip(1));
+                    // Отправить приватное сообщение
+                }
+                break;
+                
+            case "join":
+                if (args.Length > 0)
+                {
+                    // Присоединиться к каналу
+                }
+                break;
+        }
+        
+        message.Respond(ResponseStatus.Success);
+        return true;
+    }
+    
+    return base.TryHandleChatMessage(chatMessage, sender, message);
+}
+```
+
+## 모범 사례
+
+1. ** 자동 사용자 구성에 항상 AuthModule **를 사용하십시오.
+2. ** 음란 한 단어를 필터링하기 위해 Censormodule을 구성 **
+3. ** 학대를 방지하기 위해 채널의 길이를 제한하십시오 **
+4. ** 민감한 정보는 개인 메시지를 사용하십시오 **
+5. ** 다양한 목적을 위해 다양한 채널 만들기 ** (일반, 무역, 길드)
+6. ** 빈 채널을 청소하십시오 ** 리소스를 최적화합니다
+7. ** 중재 및 분석을 위해 모든 메시지 **

--- a/Docs/kr/Modules/Lobbies.md
+++ b/Docs/kr/Modules/Lobbies.md
@@ -1,1 +1,327 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Lobbies
+
+## 설명
+플레이어 그룹 만들기, 준비 상태 관리 및 게임 시작을 포함하여 게임 로비를 만들고 관리하기위한 모듈.
+
+## LobbiesModule
+
+게임 로비 관리를위한 메인 클래스.
+
+### 설정 :
+```csharp
+[Header("Configuration")]
+public int createLobbiesPermissionLevel = 0;
+public bool dontAllowCreatingIfJoined = true;
+public int joinedLobbiesLimit = 1;
+```
+
+## 로비 만들기
+
+로비 공장의 ### 등록 :
+```csharp
+// Создание фабрики
+var factory = new LobbyFactoryAnonymous("Game_Lobby", lobbyModule);
+factory.CreateNewLobbyHandler = (properties, user) =>
+{
+    var config = new LobbyConfig
+    {
+        Name = properties.AsString("name", "Game Lobby"),
+        IsPublic = properties.AsBool("isPublic", true),
+        MaxPlayers = properties.AsInt("maxPlayers", 10),
+        MaxWaitTime = properties.AsInt("maxWaitTime", 60000),
+        Teams = new List<LobbyTeam>
+        {
+            new LobbyTeam("Team A") { MaxPlayers = 5 },
+            new LobbyTeam("Team B") { MaxPlayers = 5 }
+        }
+    };
+    
+    return new GameLobby(lobbyModule.NextLobbyId(), config, lobbyModule);
+};
+
+// Регистрация фабрики
+lobbyModule.AddFactory(factory);
+```
+
+### 로비 생성 (클라이언트) :
+```csharp
+// Создание лобби
+var properties = new MstProperties();
+properties.Set(MstDictKeys.LOBBY_FACTORY_ID, "Game_Lobby");
+properties.Set("name", "Epic Battle Room");
+properties.Set("isPublic", true);
+properties.Set("maxPlayers", 8);
+
+Mst.Client.Connection.SendMessage(MstOpCodes.CreateLobby, properties, (status, response) =>
+{
+    if (status == ResponseStatus.Success)
+    {
+        int lobbyId = response.AsInt();
+        Debug.Log($"Lobby created: {lobbyId}");
+    }
+});
+```
+
+## 로비에 공동
+
+### 이익 (클라이언트) :
+```csharp
+// Присоединение к лобби
+Mst.Client.Connection.SendMessage(MstOpCodes.JoinLobby, lobbyId, (status, response) =>
+{
+    if (status == ResponseStatus.Success)
+    {
+        var lobbyData = response.AsPacket<LobbyDataPacket>();
+        Debug.Log($"Joined lobby: {lobbyData.Name}");
+        
+        // Подписка на события лобби
+        SubscribeToLobbyEvents();
+    }
+});
+
+// Покинуть лобби
+Mst.Client.Connection.SendMessage(MstOpCodes.LeaveLobby, lobbyId);
+```
+
+로비의 ## 이벤트
+
+### 이벤트 구독 :
+```csharp
+// Подписка на изменения
+Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.LobbyMemberJoined, OnMemberJoined);
+Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.LobbyMemberLeft, OnMemberLeft);
+Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.LobbyStateChange, OnLobbyStateChange);
+Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.LobbyMemberReadyStatusChange, OnMemberReadyChange);
+Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.LobbyChatMessage, OnChatMessage);
+
+// Обработчики
+private void OnMemberJoined(IIncomingMessage message)
+{
+    var memberData = message.AsPacket<LobbyMemberData>();
+    Debug.Log($"Player {memberData.Username} joined the lobby");
+}
+
+private void OnLobbyStateChange(IIncomingMessage message)
+{
+    var state = (LobbyState)message.AsInt();
+    Debug.Log($"Lobby state changed to: {state}");
+}
+```
+
+## 속성 관리
+
+로비의 ### 속성 :
+```csharp
+// Установка свойств лобби (только владелец)
+var properties = new MstProperties();
+properties.Set("map", "forest");
+properties.Set("gameMode", "battle");
+properties.Set("maxPlayers", 12);
+
+var packet = new LobbyPropertiesSetPacket
+{
+    LobbyId = currentLobbyId,
+    Properties = properties
+};
+
+Mst.Client.Connection.SendMessage(MstOpCodes.SetLobbyProperties, packet);
+```
+
+플레이어의 ### 속성 :
+```csharp
+// Установка своих свойств
+var myProperties = new Dictionary<string, string>
+{
+    { "character", "warrior" },
+    { "level", "25" },
+    { "color", "blue" }
+};
+
+Mst.Client.Connection.SendMessage(MstOpCodes.SetMyProperties, myProperties.ToBytes());
+```
+
+## 팀
+
+### 플레이어의 준비 :
+```csharp
+// Установить себя готовым
+Mst.Client.Connection.SendMessage(MstOpCodes.SetLobbyAsReady, 1);
+
+// Отменить готовность
+Mst.Client.Connection.SendMessage(MstOpCodes.SetLobbyAsReady, 0);
+```
+
+### 팀 연결 :
+```csharp
+// Присоединиться к команде
+var joinTeamPacket = new LobbyJoinTeamPacket
+{
+    LobbyId = currentLobbyId,
+    TeamName = "Team A"
+};
+
+Mst.Client.Connection.SendMessage(MstOpCodes.JoinLobbyTeam, joinTeamPacket);
+```
+
+## 로비에서 채팅
+
+### 게시물 보내기 :
+```csharp
+// Отправка сообщения в чат лобби
+string chatMessage = "Hello everyone!";
+Mst.Client.Connection.SendMessage(MstOpCodes.SendMessageToLobbyChat, chatMessage);
+
+// Получение сообщений
+private void OnChatMessage(IIncomingMessage message)
+{
+    var chatData = message.AsPacket<LobbyChatPacket>();
+    Debug.Log($"{chatData.Sender}: {chatData.Message}");
+}
+```
+
+## 게임 출시
+
+## 수동 출시 :
+```csharp
+// Начать игру (только владелец лобби)
+Mst.Client.Connection.SendMessage(MstOpCodes.StartLobbyGame, (status, response) =>
+{
+    if (status == ResponseStatus.Success)
+    {
+        Debug.Log("Game started!");
+    }
+});
+```
+
+### 자동 출시 :
+```csharp
+// Настройка автозапуска
+var config = new LobbyConfig
+{
+    EnableReadySystem = true,
+    MinPlayersToStart = 2,
+    MaxWaitTime = 30000 // 30 секунд
+};
+
+// Игра начнется автоматически когда:
+// 1. Минимум игроков готовы
+// 2. Истекло время ожидания
+```
+
+## 사용자 로비 구현
+
+```csharp
+public class RankedGameLobby : BaseLobby
+{
+    public RankedGameLobby(int lobbyId, ILobbyFactory factory, 
+        LobbiesModule module) : base(lobbyId, factory, module)
+    {
+        // Кастомные настройки
+        EnableTeamSwitching = false;
+        EnableReadySystem = true;
+        MaxPlayers = 10;
+    }
+    
+    public override bool AddPlayer(LobbyUserPeerExtension playerExt, out string error)
+    {
+        // Проверка рейтинга игрока
+        var playerProfile = GetPlayerProfile(playerExt);
+        if (playerProfile.Rating < RequiredRating)
+        {
+            error = "Rating too low for this lobby";
+            return false;
+        }
+        
+        // Автоматическое распределение по командам
+        AutoBalanceTeams(playerExt);
+        
+        return base.AddPlayer(playerExt, out error);
+    }
+    
+    protected override void OnGameStart()
+    {
+        // Кастомная логика старта
+        CalculateTeamBalance();
+        ApplyRatingModifiers();
+        
+        base.OnGameStart();
+    }
+}
+```
+
+## 다른 모듈과의 통합
+
+## Spawner :
+```csharp
+// Автоматическое создание сервера при старте игры
+protected override void OnGameStart()
+{
+    var spawnOptions = new MstProperties();
+    spawnOptions.Set("map", Properties["map"]);
+    spawnOptions.Set("gameMode", Properties["gameMode"]);
+    
+    SpawnersModule.Spawn(spawnOptions, (spawner, data) =>
+    {
+        GamePort = data.RoomPort;
+        GameIp = data.RoomIp;
+        // Игроки получат доступ к серверу
+    });
+}
+```
+
+매치 메이커와 ### :
+```csharp
+// Интеграция с матчмейкингом
+var factory = new LobbyFactoryAnonymous("Matchmaking_Lobby", lobbyModule);
+factory.CreateNewLobbyHandler = (properties, user) =>
+{
+    var matchmakingData = properties.AsPacket<MatchmakingRequestPacket>();
+    var lobby = new MatchmakingLobby();
+    
+    // Настройка на основе данных матчмейкинга
+    lobby.SetupMatchmaking(matchmakingData);
+    
+    return lobby;
+};
+```
+
+## 모범 사례
+
+1. ** 공장 사용 ** 다른 유형의 로비를 만듭니다.
+2. ** 유효한 속성 ** 플레이어를 추가하기 전에
+3. ** 공정한 게임을 위해 자동 잔액 설정 **
+4. ** 프로세스 이벤트 ** 반응 형 UI를 생성합니다
+5. ** 빈 로비를 청소하십시오 ** 무료 자원을 위해
+6. ** 디버깅 및 분석을위한 로그 액션 **
+7. ** 제한을 사용하여 남용으로부터 보호 **
+
+## 예제 UI
+
+### 로비의 간단한 목록 :
+```csharp
+public class LobbyListUI : MonoBehaviour
+{
+    [Header("UI References")]
+    public GameObject lobbyItemPrefab;
+    public Transform lobbyList;
+    
+    void Start()
+    {
+        RefreshLobbyList();
+    }
+    
+    void RefreshLobbyList()
+    {
+        // Получение списка публичных лобби
+        Mst.Client.Lobbies.GetPublicLobbies((lobbies) =>
+        {
+            foreach (var lobby in lobbies)
+            {
+                var item = Instantiate(lobbyItemPrefab, lobbyList);
+                var itemComponent = item.GetComponent<LobbyListItem>();
+                itemComponent.Setup(lobby);
+            }
+        });
+    }
+}
+```

--- a/Docs/kr/Modules/Matchmaker.md
+++ b/Docs/kr/Modules/Matchmaker.md
@@ -1,1 +1,150 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Matchmaker
+
+## 설명
+기준별로 게임, 객실 및 로비를 찾는 모듈뿐만 아니라 서버의 사용 가능한 지역에 대한 정보.
+
+## 주요 구성 요소
+
+### matchmakermodule (서버)
+```csharp
+// Зависимости
+AddOptionalDependency<LobbiesModule>();
+AddOptionalDependency<RoomsModule>();
+AddOptionalDependency<SpawnersModule>();
+
+// Основные методы
+public void AddProvider(IGamesProvider provider) // Добавить провайдер игр
+```
+
+### mstmatchmakerclient (클라이언트)
+```csharp
+// Поиск игр (без фильтров)
+matchmaker.FindGames((games) => {
+    Debug.Log($"Found {games.Count} games");
+});
+
+// Поиск игр с фильтрами
+var filters = new MstProperties();
+filters.Set("minPlayers", 2);
+matchmaker.FindGames(filters, (games) => { });
+
+// Получение регионов
+matchmaker.GetRegions((regions) => {
+    // regions[0].Name, regions[0].Ip, regions[0].PingTime
+});
+```
+
+## 키 데이터 구조
+
+### GameInfoPacket
+```csharp
+public class GameInfoPacket
+{
+    public int Id { get; set; }                    // ID игры
+    public string Address { get; set; }            // Адрес подключения
+    public GameInfoType Type { get; set; }         // Тип (Room, Lobby, Custom)
+    public string Name { get; set; }               // Название
+    public string Region { get; set; }             // Регион
+    public bool IsPasswordProtected { get; set; }  // Требуется пароль
+    public int MaxPlayers { get; set; }            // Максимум игроков
+    public int OnlinePlayers { get; set; }         // Текущее число игроков
+    public List<string> OnlinePlayersList { get; } // Список игроков
+    public MstProperties Properties { get; set; }  // Доп. свойства
+}
+```
+
+### RegionInfo
+```csharp
+public class RegionInfo
+{
+    public string Name { get; set; }  // Название региона
+    public string Ip { get; set; }    // IP-адрес
+    public int PingTime { get; set; } // Пинг (мс)
+}
+```
+
+## CASET GAMI 제공 업체
+
+### Igamesprovider 인터페이스
+```csharp
+public interface IGamesProvider
+{
+    IEnumerable<GameInfoPacket> GetPublicGames(IPeer peer, MstProperties filters);
+}
+```
+
+### 최소 구현의 예
+```csharp
+public class CustomGamesProvider : MonoBehaviour, IGamesProvider
+{
+    private List<GameInfoPacket> games = new List<GameInfoPacket>();
+    
+    public IEnumerable<GameInfoPacket> GetPublicGames(IPeer peer, MstProperties filters)
+    {
+        // Фильтрация по региону
+        if (filters.Has("region"))
+        {
+            return games.Where(g => g.Region == filters.AsString("region"));
+        }
+        
+        return games;
+    }
+    
+    // API для добавления/удаления игр
+    public void AddGame(GameInfoPacket game) => games.Add(game);
+    public void RemoveGame(int gameId) => games.RemoveAll(g => g.Id == gameId);
+}
+
+// Регистрация
+matchmaker.AddProvider(gameObject.AddComponent<CustomGamesProvider>());
+```
+
+## 사용의 예
+
+### 여러 필터가있는 게임을 검색하십시오
+```csharp
+var filters = new MstProperties();
+filters.Set("region", "eu-west");     // Только европейский регион
+filters.Set("minPlayers", 1);         // С минимум 1 игроком
+filters.Set("gameMode", "deathmatch"); // Режим "deathmatch"
+
+matchmaker.FindGames(filters, (games) =>
+{
+    // Найденные игры
+    foreach (var game in games)
+    {
+        Debug.Log($"{game.Name} - {game.OnlinePlayers}/{game.MaxPlayers}");
+        
+        // Подключение к игре
+        Mst.Client.Rooms.JoinRoom(game.Id, "", (successful, roomAccess) =>
+        {
+            if (successful)
+                ConnectToGameServer(roomAccess);
+        });
+    }
+});
+```
+
+### 최고의 핑이있는 지역의 선택
+```csharp
+matchmaker.GetRegions((regions) =>
+{
+    if (regions.Count > 0)
+    {
+        // Сортировка по пингу
+        var bestRegion = regions.OrderBy(r => r.PingTime).First();
+        PlayerPrefs.SetString("SelectedRegion", bestRegion.Name);
+        
+        Debug.Log($"Using region: {bestRegion.Name} ({bestRegion.PingTime}ms)");
+    }
+});
+```
+
+## 모범 사례
+
+1. ** 필터링에 의미있는 속성을 사용하십시오 **
+2. ** 최고의 필터 조직의 속성에 카테고리 추가 **
+3. ** 클라이언트 코드에서 게임 부족의 경우 **
+4. ** 분류 결과 ** 사용자 경험을 향상시킵니다
+5. ** 지역 목록 ** 및 필요한 경우 검색 결과를 현금화하십시오.
+6. ** 지역 목록 업데이트 ** 게임을 시작할 때

--- a/Docs/kr/Modules/Ping.md
+++ b/Docs/kr/Modules/Ping.md
@@ -1,1 +1,385 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Ping
+
+## 설명
+핑 모듈 클라이언트와 서버 간의 연결을 확인하려면 서버의 접근성을 지연하고 테스트합니다.
+
+## PingModule
+
+핑 모듈의 주요 클래스.
+
+### 설정 :
+```csharp
+[SerializeField, TextArea(3, 5)]
+private string pongMessage = "Hello, Pong!";
+```
+
+### 속성:
+```csharp
+public string PongMessage { get; set; }
+```
+
+## 서버에서 사용하십시오
+
+## H 초기화 :
+```csharp
+// Модуль автоматически регистрирует обработчик сообщений Ping
+public override void Initialize(IServer server)
+{
+    server.RegisterMessageHandler(MstOpCodes.Ping, OnPingRequestListener);
+}
+
+// Обработчик пинг-запросов
+private Task OnPingRequestListener(IIncomingMessage message)
+{
+    message.Respond(pongMessage, ResponseStatus.Success);
+    return Task.CompletedTask;
+}
+```
+
+### 설정 Pong :
+```csharp
+// Получение модуля
+var pingModule = Mst.Server.Modules.GetModule<PingModule>();
+
+// Установка сообщения
+pingModule.PongMessage = "Game server is running!";
+```
+
+## 클라이언트에서 사용하십시오
+
+### 핑 보내기 :
+```csharp
+// Отправка пинг-запроса
+Mst.Client.Connection.SendMessage(MstOpCodes.Ping, (status, response) =>
+{
+    if (status == ResponseStatus.Success)
+    {
+        // Получаем сообщение от сервера
+        string pongMessage = response.AsString();
+        
+        // Вычисляем время отклика (RTT - Round Trip Time)
+        float rtt = response.TimeElapsedSinceRequest;
+        
+        Debug.Log($"Ping successful. RTT: {rtt}ms. Message: {pongMessage}");
+    }
+    else
+    {
+        Debug.LogError("Ping failed. Server might be unavailable.");
+    }
+});
+```
+
+###주기적인 핑의 실현 :
+```csharp
+public class PingTester : MonoBehaviour
+{
+    [SerializeField] private float pingInterval = 1f;
+    [SerializeField] private int maxFailedPings = 3;
+    
+    private float nextPingTime = 0f;
+    private int failedPingsCount = 0;
+    
+    private void Update()
+    {
+        if (Time.time >= nextPingTime && Mst.Client.Connection.IsConnected)
+        {
+            nextPingTime = Time.time + pingInterval;
+            SendPing();
+        }
+    }
+    
+    private void SendPing()
+    {
+        Mst.Client.Connection.SendMessage(MstOpCodes.Ping, (status, response) =>
+        {
+            if (status == ResponseStatus.Success)
+            {
+                // Сброс счётчика неудачных попыток
+                failedPingsCount = 0;
+                
+                // Обновление отображения пинга в UI
+                float rtt = response.TimeElapsedSinceRequest;
+                UpdatePingDisplay(rtt);
+            }
+            else
+            {
+                failedPingsCount++;
+                
+                if (failedPingsCount >= maxFailedPings)
+                {
+                    // Обработка потери соединения
+                    HandleConnectionLost();
+                }
+            }
+        });
+    }
+    
+    private void UpdatePingDisplay(float rtt)
+    {
+        // Пример обновления UI
+        // pingText.text = $"Ping: {Mathf.RoundToInt(rtt)}ms";
+    }
+    
+    private void HandleConnectionLost()
+    {
+        Debug.LogWarning("Connection to server lost!");
+        // Обработка потери соединения с сервером
+    }
+}
+```
+
+## 확장 핑
+
+### 추가 정보 전송을위한 모듈 업데이트 :
+
+```csharp
+public class EnhancedPingModule : PingModule
+{
+    [SerializeField] private int serverCurrentLoad = 0;
+    [SerializeField] private int maxServerLoad = 100;
+    
+    private Task OnPingRequestListener(IIncomingMessage message)
+    {
+        // Создаем расширенный ответ с дополнительной информацией
+        var pingResponse = new PingResponseInfo
+        {
+            Message = PongMessage,
+            ServerTime = System.DateTime.UtcNow.Ticks,
+            ServerLoad = serverCurrentLoad,
+            MaxServerLoad = maxServerLoad,
+            OnlinePlayers = Mst.Server.ConnectionsCount
+        };
+        
+        // Преобразуем в JSON
+        string jsonResponse = JsonUtility.ToJson(pingResponse);
+        
+        // Отправляем ответ
+        message.Respond(jsonResponse, ResponseStatus.Success);
+        return Task.CompletedTask;
+    }
+    
+    // Обновление информации о нагрузке
+    public void UpdateServerLoad(int currentLoad)
+    {
+        serverCurrentLoad = currentLoad;
+    }
+    
+    [System.Serializable]
+    private class PingResponseInfo
+    {
+        public string Message;
+        public long ServerTime;
+        public int ServerLoad;
+        public int MaxServerLoad;
+        public int OnlinePlayers;
+    }
+}
+```
+
+## 확장 된 답변의 클라이언트 처리 :
+
+```csharp
+// Отправка запроса
+Mst.Client.Connection.SendMessage(MstOpCodes.Ping, (status, response) =>
+{
+    if (status == ResponseStatus.Success)
+    {
+        string jsonResponse = response.AsString();
+        
+        try
+        {
+            // Парсинг JSON-ответа
+            PingResponseInfo pingInfo = JsonUtility.FromJson<PingResponseInfo>(jsonResponse);
+            
+            // Использование информации
+            Debug.Log($"Server message: {pingInfo.Message}");
+            Debug.Log($"Server time: {new System.DateTime(pingInfo.ServerTime)}");
+            Debug.Log($"Server load: {pingInfo.ServerLoad}/{pingInfo.MaxServerLoad}");
+            Debug.Log($"Online players: {pingInfo.OnlinePlayers}");
+            
+            // Расчёт разницы во времени между клиентом и сервером
+            long clientTime = System.DateTime.UtcNow.Ticks;
+            TimeSpan timeDifference = new System.DateTime(pingInfo.ServerTime) - new System.DateTime(clientTime);
+            Debug.Log($"Time difference: {timeDifference.TotalMilliseconds}ms");
+        }
+        catch
+        {
+            // Если ответ в старом формате, обрабатываем как строку
+            Debug.Log($"Server message: {jsonResponse}");
+        }
+    }
+});
+```
+
+## 다른 시스템과의 통합
+
+### 연결 모니터링 :
+```csharp
+public class ConnectionMonitor : MonoBehaviour
+{
+    [SerializeField] private float pingInterval = 5f;
+    [SerializeField] private float maxPingTime = 500f; // ms
+    
+    private List<float> pingsHistory = new List<float>();
+    private int historySize = 10;
+    
+    private void Start()
+    {
+        StartCoroutine(PingRoutine());
+    }
+    
+    private IEnumerator PingRoutine()
+    {
+        while (true)
+        {
+            if (Mst.Client.Connection.IsConnected)
+            {
+                SendPing();
+            }
+            
+            yield return new WaitForSeconds(pingInterval);
+        }
+    }
+    
+    private void SendPing()
+    {
+        Mst.Client.Connection.SendMessage(MstOpCodes.Ping, (status, response) =>
+        {
+            if (status == ResponseStatus.Success)
+            {
+                float rtt = response.TimeElapsedSinceRequest;
+                
+                // Добавляем в историю
+                pingsHistory.Add(rtt);
+                
+                // Поддерживаем ограниченный размер истории
+                if (pingsHistory.Count > historySize)
+                {
+                    pingsHistory.RemoveAt(0);
+                }
+                
+                // Проверка на высокий пинг
+                if (rtt > maxPingTime)
+                {
+                    OnHighPingDetected(rtt);
+                }
+                
+                // Уведомление о среднем пинге
+                float averagePing = pingsHistory.Average();
+                OnPingUpdated(rtt, averagePing);
+            }
+            else
+            {
+                OnPingFailed();
+            }
+        });
+    }
+    
+    // События для интеграции с игровыми системами
+    private void OnPingUpdated(float currentPing, float averagePing)
+    {
+        // Обновление UI или состояния игры
+    }
+    
+    private void OnHighPingDetected(float ping)
+    {
+        // Предупреждение игрока о плохом соединении
+    }
+    
+    private void OnPingFailed()
+    {
+        // Обработка неудачной попытки пинга
+    }
+}
+```
+
+### 자동 재 연결 :
+```csharp
+public class AutoReconnector : MonoBehaviour
+{
+    [SerializeField] private float checkInterval = 5f;
+    [SerializeField] private int maxFailedPings = 3;
+    [SerializeField] private int maxReconnectAttempts = 5;
+    
+    private int failedPingsCount = 0;
+    private int reconnectAttempts = 0;
+    
+    private void Start()
+    {
+        StartCoroutine(ConnectionCheckRoutine());
+    }
+    
+    private IEnumerator ConnectionCheckRoutine()
+    {
+        while (true)
+        {
+            if (Mst.Client.Connection.IsConnected)
+            {
+                // Проверка соединения через пинг
+                CheckConnection();
+            }
+            else if (reconnectAttempts < maxReconnectAttempts)
+            {
+                // Попытка переподключения
+                AttemptReconnect();
+            }
+            
+            yield return new WaitForSeconds(checkInterval);
+        }
+    }
+    
+    private void CheckConnection()
+    {
+        Mst.Client.Connection.SendMessage(MstOpCodes.Ping, (status, response) =>
+        {
+            if (status == ResponseStatus.Success)
+            {
+                // Соединение работает, сбрасываем счётчики
+                failedPingsCount = 0;
+                reconnectAttempts = 0;
+            }
+            else
+            {
+                failedPingsCount++;
+                
+                if (failedPingsCount >= maxFailedPings)
+                {
+                    Debug.LogWarning("Connection lost. Attempting to reconnect...");
+                    AttemptReconnect();
+                }
+            }
+        });
+    }
+    
+    private void AttemptReconnect()
+    {
+        reconnectAttempts++;
+        
+        Debug.Log($"Reconnect attempt {reconnectAttempts}/{maxReconnectAttempts}");
+        
+        // Попытка переподключения
+        Mst.Client.Connection.Connect(Mst.Client.Connection.ConnectionIp, Mst.Client.Connection.ConnectionPort, (isSuccessful, error) =>
+        {
+            if (isSuccessful)
+            {
+                Debug.Log("Successfully reconnected");
+                failedPingsCount = 0;
+            }
+            else
+            {
+                Debug.LogError($"Failed to reconnect: {error}");
+            }
+        });
+    }
+}
+```
+
+## 모범 사례
+
+1. ** 연결 상태를 모니터링하려면 핑을 사용하십시오 ** -주기 점검은 일찍 문제를 감지하는 데 도움이됩니다.
+2. ** 자동 재 연결 향상 ** 연결 손실을 감지 할 때
+3. ** 연결의 안정성을 분석하려면 핑의 역사를 유지하십시오.
+4. ** 핑을 UI로 표시하여 플레이어에게 연결의 품질에 대해 알리십시오.
+5. ** 서버에 대한 추가 정보를 전송하려면 기본 기능을 확장하십시오.
+6. ** 합리적인 핑 간격 설치 ** - 너무 빈번한 요청은 추가 부하를 생성 할 수 있습니다.
+7. ** 게임 플레이를 연결의 현재 상태로 조정하십시오. 예를 들어, High Ping에서 전송 된 참조 수를 줄입니다.

--- a/Docs/kr/Modules/Profiles.md
+++ b/Docs/kr/Modules/Profiles.md
@@ -1,1 +1,276 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Profiles
+
+## 설명
+관리 데이터, 변경 관찰 및 고객과 서버 간의 동기화에 대한 프로파일 모듈.
+
+## ProfilesModule
+
+사용자 프로필 관리를위한 메인 클래스.
+
+### 설정 :
+```csharp
+[Header("General Settings")]
+[SerializeField] protected int unloadProfileAfter = 20;
+[SerializeField] protected int saveProfileDebounceTime = 1;
+[SerializeField] protected int clientUpdateDebounceTime = 1;
+[SerializeField] protected int editProfilePermissionLevel = 0;
+[SerializeField] protected int maxUpdateSize = 1048576;
+
+[Header("Timeout Settings")]
+[SerializeField] protected int profileLoadTimeoutSeconds = 10;
+
+[Header("Database")]
+public DatabaseAccessorFactory databaseAccessorFactory;
+[SerializeField] private ObservablePropertyPopulatorsDatabase populatorsDatabase;
+```
+
+## 프로필의 속성
+
+## 속성 시스템 생성 :
+```csharp
+// Создание популятора
+public class PlayerStatsPopulator : IObservablePropertyPopulator
+{
+    public IProperty Populate()
+    {
+        var properties = new ObservableBase();
+        
+        // Базовые статы
+        properties.Set("playerLevel", new ObservableInt(1));
+        properties.Set("experience", new ObservableInt(0));
+        properties.Set("coins", new ObservableInt(0));
+        
+        // Словарь для инвентаря
+        var inventory = new ObservableDictStringInt();
+        inventory.Add("sword", 1);
+        inventory.Add("potion", 5);
+        properties.Set("inventory", inventory);
+        
+        return properties;
+    }
+}
+```
+
+## 프로필과 함께 작업하십시오
+
+### 프로필에 대한 액세스 (클라이언트) :
+```csharp
+// Запрос профиля
+Mst.Client.Connection.SendMessage(MstOpCodes.ClientFillInProfileValues);
+
+// Подписка на обновления
+Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.UpdateClientProfile, OnProfileUpdated);
+
+// Обработка ответа
+private void OnProfileUpdated(IIncomingMessage message)
+{
+    var profile = new ObservableProfile();
+    profile.FromBytes(message.AsBytes());
+    
+    // Доступ к свойствам
+    int level = profile.GetProperty<ObservableInt>("playerLevel").Value;
+    int coins = profile.GetProperty<ObservableInt>("coins").Value;
+}
+```
+
+### 프로필에 대한 액세스 (서버) :
+```csharp
+// Получение профиля по Id
+var profile = profilesModule.GetProfileByUserId(userId);
+
+// Получение профиля по Peer
+var profile = profilesModule.GetProfileByPeer(peer);
+
+// Изменение профиля
+profile.GetProperty<ObservableInt>("playerLevel").Add(1);
+profile.GetProperty<ObservableInt>("coins").Set(100);
+```
+
+## 프로필 이벤트
+
+### 변경 사항 구독 :
+```csharp
+// На сервере
+profilesModule.OnProfileCreated += OnProfileCreated;
+profilesModule.OnProfileLoaded += OnProfileLoaded;
+
+// В профиле
+profile.OnModifiedInServerEvent += OnProfileChanged;
+
+// Конкретное свойство
+profile.GetProperty<ObservableInt>("playerLevel").OnDirtyEvent += OnLevelChanged;
+```
+
+## 데이터베이스와 동기화
+
+## Selume iprofilesdatabaseaccessor :
+```csharp
+public class ProfilesDatabaseAccessor : IProfilesDatabaseAccessor
+{
+    public async Task RestoreProfileAsync(ObservableServerProfile profile)
+    {
+        // Загрузка из БД
+        var data = await LoadProfileDataFromDB(profile.UserId);
+        if (data != null)
+        {
+            profile.FromBytes(data);
+        }
+    }
+    
+    public async Task UpdateProfilesAsync(List<ObservableServerProfile> profiles)
+    {
+        // Batch сохранение в БД
+        foreach (var profile in profiles)
+        {
+            await SaveProfileToDB(profile.UserId, profile.ToBytes());
+        }
+    }
+}
+```
+
+## 관찰 된 속성의 유형
+
+## 기본 유형 :
+```csharp
+// Числовые
+ObservableInt level = new ObservableInt(10);
+ObservableFloat health = new ObservableFloat(100.0f);
+
+// Строки
+ObservableString name = new ObservableString("Player");
+
+// Списки
+ObservableListInt scores = new ObservableListInt();
+scores.Add(100);
+
+// Словари
+ObservableDictStringInt items = new ObservableDictStringInt();
+items.Add("sword", 1);
+```
+
+## 서버 업데이트
+
+### 게임 서버에서 업데이트 보내기 :
+```csharp
+// Создание пакета обновлений
+var updates = new ProfileUpdatePacket();
+updates.UserId = userId;
+updates.Properties = new MstProperties();
+updates.Properties.Set("playerLevel", 15);
+updates.Properties.Set("experience", 1500);
+
+// Отправка на master server
+Mst.Server.Connection.SendMessage(MstOpCodes.ServerUpdateProfileValues, updates);
+```
+
+## 성능 및 최적화
+
+### 분해 설정 :
+```csharp
+// Задержка сохранения в БД (секунды)
+saveProfileDebounceTime = 1;
+
+// Задержка отправки обновлений клиенту
+clientUpdateDebounceTime = 0.5f;
+
+// Время до выгрузки профиля после выхода
+unloadProfileAfter = 20;
+```
+
+### 제한:
+```csharp
+// Максимальный размер обновления
+maxUpdateSize = 1048576;
+
+// Тайм-аут загрузки профиля
+profileLoadTimeoutSeconds = 10;
+```
+
+## 사용의 예
+
+### 게임 통계 :
+```csharp
+public class PlayerStats
+{
+    public ObservableInt Level { get; private set; }
+    public ObservableInt Experience { get; private set; }
+    public ObservableFloat Health { get; private set; }
+    public ObservableDictStringInt Inventory { get; private set; }
+    
+    public PlayerStats(ObservableServerProfile profile)
+    {
+        Level = profile.GetProperty<ObservableInt>("playerLevel");
+        Experience = profile.GetProperty<ObservableInt>("experience");
+        Health = profile.GetProperty<ObservableFloat>("health");
+        Inventory = profile.GetProperty<ObservableDictStringInt>("inventory");
+    }
+    
+    public void AddExperience(int amount)
+    {
+        Experience.Add(amount);
+        
+        if (Experience.Value >= GetExperienceForNextLevel())
+        {
+            LevelUp();
+        }
+    }
+    
+    private void LevelUp()
+    {
+        Level.Add(1);
+        Health.Set(100.0f); // Восстановление здоровья при уровне
+        Experience.Set(0);
+    }
+}
+```
+
+## 클라이언트 프로필 :
+```csharp
+public class ProfileUI : MonoBehaviour
+{
+    [Header("UI References")]
+    public Text levelText;
+    public Text coinsText;
+    public Text healthText;
+    
+    private ObservableProfile profile;
+    
+    void Start()
+    {
+        // Запрос профиля
+        Mst.Client.Connection.SendMessage(MstOpCodes.ClientFillInProfileValues);
+        
+        // Регистрация обработчика обновлений
+        Mst.Client.Connection.RegisterMessageHandler(MstOpCodes.UpdateClientProfile, OnProfileUpdate);
+    }
+    
+    private void OnProfileUpdate(IIncomingMessage message)
+    {
+        if (profile == null)
+            profile = new ObservableProfile();
+            
+        profile.ApplyUpdates(message.AsBytes());
+        
+        // Обновление UI
+        UpdateUI();
+    }
+    
+    private void UpdateUI()
+    {
+        levelText.text = $"Level: {profile.GetProperty<ObservableInt>("playerLevel").Value}";
+        coinsText.text = $"Coins: {profile.GetProperty<ObservableInt>("coins").Value}";
+        healthText.text = $"Health: {profile.GetProperty<ObservableFloat>("health").Value}";
+    }
+}
+```
+
+## 모범 사례
+
+1. ** 인구 **를 사용하여 프로파일을 초기화합니다
+2. ** 그룹 업데이트 ** 하중을 줄입니다
+3. ** 참조 디바운드 ** 성능을 최적화합니다
+4. ** 공격을 방지하려면 업데이트 크기를 확인하십시오 **
+5. ** 안전을 위해 일반적인 속성 **를 사용하십시오
+6. ** 이벤트 구독 ** 반응성 프로그래밍을 위해
+7. ** 사용하지 않는 프로파일을 청소하십시오 ** 메모리를 해제하십시오
+8. ** 중요한 데이터의 경우 백업을 향상시킵니다

--- a/Docs/kr/Modules/QuestsModule.md
+++ b/Docs/kr/Modules/QuestsModule.md
@@ -1,1 +1,192 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Quests
+
+## 설명
+작업 체인, 임시 제한 및 상을 설정할 가능성이있는 게임 퀘스트를 작성, 추적 및 수행하기위한 모듈.
+
+## 주요 구조
+
+### QuestData (ScriptableObject)
+```csharp
+[CreateAssetMenu(menuName = "Master Server Toolkit/Quests/New Quest")]
+public class QuestData : ScriptableObject
+{
+    // Основная информация
+    public string Key => key;                 // Уникальный ключ квеста
+    public string Title => title;             // Название
+    public string Description => description; // Описание
+    public int RequiredProgress => requiredProgress; // Кол-во для завершения
+    public Sprite Icon => icon;               // Иконка квеста
+    
+    // Сообщения для разных статусов
+    public string StartMessage => startMessage;       // Сообщение при взятии квеста
+    public string ActiveMessage => activeMessage;     // Сообщение во время выполнения
+    public string CompletedMessage => completedMessage; // Сообщение при завершении
+    public string CancelMessage => cancelMessage;      // Сообщение при отмене
+    public string ExpireMessage => expireMessage;      // Сообщение при истечении срока
+    
+    // Настройки
+    public bool IsOneTime => isOneTime;               // Одноразовый квест
+    public int TimeToComplete => timeToComplete;      // Время на выполнение (мин)
+    
+    // Связи с другими квестами
+    public QuestData ParentQuest => parentQuest;       // Родительский квест
+    public QuestData[] ChildrenQuests => childrenQuests; // Дочерние квесты
+}
+```
+
+### 퀘스트 상태
+```csharp
+public enum QuestStatus 
+{ 
+    Inactive,   // Квест неактивен
+    Active,     // Квест активен
+    Completed,  // Квест завершен
+    Canceled,   // Квест отменен
+    Expired     // Время квеста истекло
+}
+```
+
+### iquestinfo 인터페이스
+```csharp
+public interface IQuestInfo
+{
+    string Id { get; set; }                 // Уникальный ID
+    string Key { get; set; }                // Ключ квеста
+    string UserId { get; set; }             // ID пользователя
+    int Progress { get; set; }              // Текущий прогресс
+    int Required { get; set; }              // Требуемый прогресс
+    DateTime StartTime { get; set; }        // Время начала
+    DateTime ExpireTime { get; set; }       // Время истечения
+    DateTime CompleteTime { get; set; }     // Время завершения
+    QuestStatus Status { get; set; }        // Статус
+    string ParentQuestKey { get; set; }     // Ключ родительского квеста
+    string ChildrenQuestsKeys { get; set; } // Ключи дочерних квестов
+    bool TryToComplete(int progress);       // Метод для завершения квеста
+}
+```
+
+## QuestsModule (서버)
+
+```csharp
+// Зависимости
+AddDependency<AuthModule>();
+AddDependency<ProfilesModule>();
+
+// Настройки
+[Header("Permission"), SerializeField]
+protected bool clientCanUpdateProgress = false; // Может ли клиент обновлять прогресс
+
+[Header("Settings"), SerializeField]
+protected QuestsDatabase[] questsDatabases; // Базы данных квестов
+```
+
+### 기본 서버 작업
+1. 퀘스트 목록을 얻습니다
+2. 퀘스트의 시작
+3. 퀘스트의 진행 상황 업데이트
+4. 퀘스트의 폐지
+5. 퀘스트 기간의 만료를 확인하십시오
+
+### 프로필과 통합
+```csharp
+private void ProfilesModule_OnProfileLoaded(ObservableServerProfile profile)
+{
+    if (profile.TryGet(ProfilePropertyOpCodes.quests, out ObservableQuests property))
+    {
+        // Инициализация квестов пользователя
+    }
+}
+```
+
+## quesmoduleclient (클라이언트)
+
+```csharp
+// Получение списка доступных квестов
+questsClient.GetQuests((quests) => {
+    foreach (var quest in quests)
+    {
+        Debug.Log($"Quest: {quest.Title}, Status: {quest.Status}");
+    }
+});
+
+// Начать квест
+questsClient.StartQuest("quest_key", (isStarted, quest) => {
+    if (isStarted)
+        Debug.Log($"Started quest: {quest.Title}");
+});
+
+// Обновить прогресс квеста
+questsClient.UpdateQuestProgress("quest_key", 5, (isUpdated) => {
+    if (isUpdated)
+        Debug.Log("Quest progress updated");
+});
+
+// Отменить квест
+questsClient.CancelQuest("quest_key", (isCanceled) => {
+    if (isCanceled)
+        Debug.Log("Quest canceled");
+});
+```
+
+## 퀘스트 생성의 예
+
+### 퀘스트 데이터베이스를 만듭니다
+```csharp
+// В редакторе Unity
+[CreateAssetMenu(menuName = "Master Server Toolkit/Quests/QuestsDatabase")]
+public class QuestsDatabase : ScriptableObject
+{
+    [SerializeField]
+    private List<QuestData> quests = new List<QuestData>();
+    
+    public IReadOnlyCollection<QuestData> Quests => quests;
+}
+
+// Создание базы данных
+var database = ScriptableObject.CreateInstance<QuestsDatabase>();
+```
+
+## 퀘스트 생성
+```csharp
+// В редакторе Unity
+var quest = ScriptableObject.CreateInstance<QuestData>();
+quest.name = "CollectResources";
+// Настройка квеста через инспектор
+
+// Программно
+var questData = new QuestData
+{
+    Key = "collect_wood",
+    Title = "Collect Wood",
+    Description = "Collect 10 pieces of wood",
+    RequiredProgress = 10,
+    TimeToComplete = 60 // 60 минут на выполнение
+};
+```
+
+### 퀘스트 체인
+```csharp
+// Создание зависимостей между квестами
+var mainQuest = ScriptableObject.CreateInstance<QuestData>();
+mainQuest.name = "MainQuest";
+
+var subQuest1 = ScriptableObject.CreateInstance<QuestData>();
+subQuest1.name = "SubQuest1";
+// Установка mainQuest как родительского для subQuest1
+
+var subQuest2 = ScriptableObject.CreateInstance<QuestData>();
+subQuest2.name = "SubQuest2";
+// Установка mainQuest как родительского для subQuest2
+
+// В родительском квесте указываем дочерние
+// mainQuest.ChildrenQuests = new QuestData[] { subQuest1, subQuest2 };
+```
+
+## 모범 사례
+
+1. ** 가장 좋은 식별을 위해 의미있는 퀘스트 키 생성 **
+2. ** Group Quests ** 주제별 데이터베이스
+3. ** 퀘스트 실행의 현실적인 마감일을 결정하십시오.
+4. ** 퀘스트 체인 사용 ** 플롯 라인을 만듭니다.
+5. ** 퀘스트를 처리 할 때 실패 허용 오차를 제공합니다. **
+6. ** 명확한 메시지 제공 ** 각 퀘스트 상태에 대해.

--- a/Docs/kr/Modules/Rooms.md
+++ b/Docs/kr/Modules/Rooms.md
@@ -1,1 +1,355 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Rooms
+
+## 설명
+게임 룸에 대한 등록, 관리 및 제공 모듈.공개 및 개인 실을 만들고 매개 변수를 관리하고 플레이어 액세스를 제어 할 수 있습니다.
+
+## RoomsModule
+
+마스터 서버의 객실 관리를위한 메인 클래스.
+
+### 설정 :
+```csharp
+[Header("Permissions")]
+[SerializeField] protected int registerRoomPermissionLevel = 0;
+```
+
+## 방의 등록
+
+### 게임 서버 :
+```csharp
+// Создание опций комнаты
+var options = new RoomOptions
+{
+    Name = "Epic Battle Arena",
+    RoomIp = "192.168.1.100",
+    RoomPort = 7777,
+    MaxConnections = 16,
+    IsPublic = true,
+    Password = "", // пустой для публичной комнаты
+    Region = "RU",
+    CustomOptions = new MstProperties()
+};
+
+// Добавляем кастомные свойства
+options.CustomOptions.Set("map", "forest_arena");
+options.CustomOptions.Set("gameMode", "battle_royale");
+options.CustomOptions.Set("difficulty", "hard");
+
+// Регистрация на master server
+Mst.Server.Rooms.RegisterRoom(options, (room, error) =>
+{
+    if (room != null)
+    {
+        Debug.Log($"Room registered with ID: {room.RoomId}");
+    }
+    else
+    {
+        Debug.LogError($"Failed to register room: {error}");
+    }
+});
+```
+
+### 자동 등록 :
+```csharp
+public class GameServerManager : MonoBehaviour
+{
+    [Header("Room Settings")]
+    public string roomName = "Game Room";
+    public int maxPlayers = 10;
+    public bool isPublic = true;
+    
+    void Start()
+    {
+        RegisterGameRoom();
+    }
+    
+    private void RegisterGameRoom()
+    {
+        var options = new RoomOptions
+        {
+            Name = roomName,
+            RoomIp = GetServerIp(),
+            RoomPort = NetworkManager.singleton.networkPort,
+            MaxConnections = maxPlayers,
+            IsPublic = isPublic
+        };
+        
+        Mst.Server.Rooms.RegisterRoom(options);
+    }
+}
+```
+
+## 객실 관리
+
+### 매개 변수 업데이트 :
+```csharp
+// Изменение опций комнаты
+var newOptions = room.Options;
+newOptions.MaxConnections = 20;
+newOptions.CustomOptions.Set("gameState", "playing");
+
+Mst.Server.Rooms.SaveRoomOptions(room.RoomId, newOptions);
+
+// Управление игроками
+room.AddPlayer(peerId, peer);
+room.RemovePlayer(peerId);
+
+// Получение списка игроков
+var players = room.Players.Values;
+```
+
+### 방의 파괴 :
+```csharp
+// При завершении игры
+Mst.Server.Rooms.DestroyRoom(room.RoomId, (successful, error) =>
+{
+    if (successful)
+    {
+        Debug.Log("Room destroyed successfully");
+    }
+});
+
+// Автоматическое уничтожение при отключении
+void OnApplicationQuit()
+{
+    if (registeredRoom != null)
+    {
+        Mst.Server.Rooms.DestroyRoom(registeredRoom.RoomId);
+    }
+}
+```
+
+## 방에 연결
+
+## 검색 및 연결 :
+```csharp
+// Поиск публичных комнат
+Mst.Client.Matchmaker.FindGames((games) =>
+{
+    foreach (var game in games)
+    {
+        Debug.Log($"Room: {game.Name}, Players: {game.OnlinePlayers}/{game.MaxPlayers}");
+    }
+});
+
+// Подключение к конкретной комнате
+var roomId = 12345;
+Mst.Client.Rooms.GetAccess(roomId, "", (access, error) =>
+{
+    if (access != null)
+    {
+        ConnectToGameServer(access.RoomIp, access.RoomPort, access.Token);
+    }
+});
+```
+
+### 비밀번호 연결 :
+```csharp
+// Подключение к приватной комнате
+Mst.Client.Rooms.GetAccess(roomId, "secret_password", (access, error) =>
+{
+    if (access != null)
+    {
+        Debug.Log("Access granted!");
+        JoinGameServer(access.RoomIp, access.RoomPort, access.Token);
+    }
+    else
+    {
+        Debug.LogError("Invalid password");
+    }
+});
+```
+
+## 게임 서버와 통합
+
+### RoomServerManager:
+```csharp
+public class RoomServerManager : MonoBehaviour
+{
+    [Header("Refs")]
+    public NetworkManager networkManager;
+    
+    private RegisteredRoom currentRoom;
+    
+    void Start()
+    {
+        // Запуск сервера
+        networkManager.StartServer();
+        
+        // Регистрация комнаты
+        RegisterRoom();
+    }
+    
+    public override void OnServerConnect(NetworkConnectionToClient conn)
+    {
+        // Проверка токена доступа
+        ValidatePlayerAccess(conn);
+    }
+    
+    private void ValidatePlayerAccess(NetworkConnectionToClient conn)
+    {
+        // Получение токена от клиента
+        string accessToken = GetTokenFromClient(conn);
+        
+        // Проверка на master server
+        Mst.Server.Rooms.ValidateAccess(currentRoom.RoomId, accessToken, (userData, error) =>
+        {
+            if (userData != null)
+            {
+                // Доступ разрешен
+                acceptedPlayers[conn.connectionId] = userData;
+                Debug.Log($"Player {userData.Username} validated");
+            }
+            else
+            {
+                // Отклонить подключение
+                conn.Disconnect();
+            }
+        });
+    }
+}
+```
+
+## 필터링 룸
+
+### 기준 별 검색 :
+```csharp
+// Создание фильтров
+var filters = new MstProperties();
+filters.Set("map", "forest");
+filters.Set("gameMode", "pvp");
+filters.Set("maxPlayers", 10);
+
+// Поиск комнат с фильтрами
+Mst.Client.Matchmaker.FindGames(filters, (games) =>
+{
+    var filteredRooms = games.Where(g => 
+        g.Type == GameInfoType.Room &&
+        g.OnlinePlayers < g.MaxPlayers &&
+        !g.IsPasswordProtected
+    );
+});
+```
+
+## 카스트 필터링 :
+```csharp
+// На стороне сервера - переопределение GetPublicRoomOptions
+public override MstProperties GetPublicRoomOptions(IPeer player, RegisteredRoom room, MstProperties playerFilters)
+{
+    var roomData = base.GetPublicRoomOptions(player, room, playerFilters);
+    
+    // Добавляем дополнительную информацию
+    roomData.Set("serverVersion", "1.2.3");
+    roomData.Set("ping", CalculatePing(player, room));
+    
+    // Скрываем некоторые данные
+    if (!IsAdminPlayer(player))
+    {
+        roomData.Remove("adminPort");
+    }
+    
+    return roomData;
+}
+```
+
+## 방의 이벤트
+
+### 이벤트 구독 :
+```csharp
+// На мастер сервере
+roomsModule.OnRoomRegisteredEvent += (room) =>
+{
+    Debug.Log($"New room registered: {room.Options.Name}");
+    NotifyMatchmakingSystem(room);
+};
+
+roomsModule.OnRoomDestroyedEvent += (room) =>
+{
+    Debug.Log($"Room destroyed: {room.RoomId}");
+    CleanupResources(room);
+};
+
+// В игровой комнате
+room.OnPlayerJoinedEvent += (player) =>
+{
+    SendWelcomeMessage(player);
+    UpdatePlayerCount();
+};
+
+room.OnPlayerLeftEvent += (player) =>
+{
+    SavePlayerProgress(player);
+    CheckIfRoomShouldClose();
+};
+```
+
+## 객실 목록의 경우 UI
+
+```csharp
+public class RoomListUI : MonoBehaviour
+{
+    [Header("UI")]
+    public GameObject roomItemPrefab;
+    public Transform roomList;
+    public Button refreshButton;
+    
+    void Start()
+    {
+        refreshButton.onClick.AddListener(RefreshRoomList);
+        RefreshRoomList();
+    }
+    
+    void RefreshRoomList()
+    {
+        // Очистка списка
+        foreach (Transform child in roomList)
+        {
+            Destroy(child.gameObject);
+        }
+        
+        // Получение комнат
+        Mst.Client.Matchmaker.FindGames((games) =>
+        {
+            foreach (var game in games)
+            {
+                if (game.Type == GameInfoType.Room)
+                {
+                    CreateRoomItem(game);
+                }
+            }
+        });
+    }
+    
+    void CreateRoomItem(GameInfoPacket room)
+    {
+        var item = Instantiate(roomItemPrefab, roomList);
+        var roomUI = item.GetComponent<RoomItem>();
+        
+        roomUI.Setup(room);
+        roomUI.OnJoinClicked = () => JoinRoom(room.Id);
+    }
+    
+    void JoinRoom(int roomId)
+    {
+        Mst.Client.Rooms.GetAccess(roomId, (access, error) =>
+        {
+            if (access != null)
+            {
+                NetworkManager.singleton.networkAddress = access.RoomIp;
+                NetworkManager.singleton.StartClient();
+            }
+        });
+    }
+}
+```
+
+## 모범 사례
+
+1. ** 게임 서버에서 항상 액세스 토큰을 확인하십시오 **
+2. ** 유연한 객실 설정에 맞춤 속성 사용 **
+3. ** 서버 시작 후 객실 등록 **
+4. ** 플레이어 수를 실시간으로 업데이트하십시오.
+5. ** 청소 자원 ** 방을 파괴 할 때
+6. ** 개인 실에 비밀번호 **를 사용하십시오
+7. ** 객실 상태 모니터 ** 리소스 최적화
+8. ** 필터 사용 ** 객실에 대한 최고의 UX 검색을 위해

--- a/Docs/kr/Modules/Spawner.md
+++ b/Docs/kr/Modules/Spawner.md
@@ -1,1 +1,245 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Spawner
+
+## 설명
+로드 밸런싱 및 큐를 지원하는 다양한 지역에서 게임 서버를 시작하는 프로세스를 관리하기위한 모듈.
+
+## 주요 구성 요소
+
+### SpawnersModule
+```csharp
+// Настройки
+[SerializeField] protected int createSpawnerPermissionLevel = 0; // Минимальный уровень прав для регистрации спаунера
+[SerializeField] protected float queueUpdateFrequency = 0.1f;    // Частота обновления очередей
+[SerializeField] protected bool enableClientSpawnRequests = true; // Разрешить запросы на спаун от клиентов
+
+// События
+public event Action<RegisteredSpawner> OnSpawnerRegisteredEvent;  // При регистрации спаунера
+public event Action<RegisteredSpawner> OnSpawnerDestroyedEvent;   // При удалении спаунера
+public event SpawnedProcessRegistrationHandler OnSpawnedProcessRegisteredEvent; // При регистрации процесса
+```
+
+### RegisteredSpawner
+```csharp
+// Основные свойства
+public int SpawnerId { get; }                // Уникальный ID спаунера
+public IPeer Peer { get; }                   // Подключение к спаунеру
+public SpawnerOptions Options { get; }       // Настройки спаунера
+public int ProcessesRunning { get; }         // Количество запущенных процессов
+public int QueuedTasks { get; }              // Количество задач в очереди
+
+// Методы
+public bool CanSpawnAnotherProcess();        // Может ли запустить еще один процесс
+public int CalculateFreeSlotsCount();        // Расчет количества свободных слотов
+```
+
+### SpawnerOptions
+```csharp
+// Настройки спаунера
+public string MachineIp { get; set; }           // IP машины спаунера 
+public int MaxProcesses { get; set; } = 5;      // Максимальное количество процессов
+public string Region { get; set; } = "Global";  // Регион спаунера
+public Dictionary<string, string> CustomOptions { get; set; } // Дополнительные настройки
+```
+
+### SpawnTask
+```csharp
+// Свойства
+public int Id { get; }                      // ID задачи
+public RegisteredSpawner Spawner { get; }   // Спаунер, выполняющий задачу
+public MstProperties Options { get; }       // Настройки запуска
+public SpawnStatus Status { get; }          // Текущий статус
+public string UniqueCode { get; }           // Уникальный код для безопасности
+public IPeer Requester { get; set; }        // Запросивший клиент
+public IPeer RegisteredPeer { get; private set; } // Зарегистрированный процесс
+
+// События
+public event Action<SpawnStatus> OnStatusChangedEvent; // При изменении статуса
+```
+
+## spawnstatus 프로세스 상태
+```csharp
+public enum SpawnStatus
+{
+    None,               // Начальный статус
+    Queued,             // В очереди
+    ProcessStarted,     // Процесс запущен
+    ProcessRegistered,  // Процесс зарегистрирован
+    Finalized,          // Финализирован
+    Aborted,            // Прерван
+    Killed              // Убит
+}
+```
+
+## 작업 과정
+
+### 버스터 등록
+```csharp
+// Клиент
+var options = new SpawnerOptions
+{
+    MachineIp = "192.168.1.10",
+    MaxProcesses = 10,
+    Region = "eu-west",
+    CustomOptions = new Dictionary<string, string> {
+        { "mapsList", "map1,map2,map3" }
+    }
+};
+
+Mst.Client.Spawners.RegisterSpawner(options, (successful, spawnerId) =>
+{
+    if (successful)
+        Debug.Log($"Spawner registered with ID: {spawnerId}");
+});
+
+// Сервер
+RegisteredSpawner spawner = CreateSpawner(peer, options);
+```
+
+### 게임 서버 출시 요청
+```csharp
+// Клиент
+var spawnOptions = new MstProperties();
+spawnOptions.Set(Mst.Args.Names.RoomName, "MyGame");
+spawnOptions.Set(Mst.Args.Names.RoomMaxPlayers, 10);
+spawnOptions.Set(Mst.Args.Names.RoomRegion, "eu-west");
+
+Mst.Client.Spawners.RequestSpawn(spawnOptions, (successful, spawnId) =>
+{
+    if (successful)
+    {
+        Debug.Log($"Spawn request created with ID: {spawnId}");
+        
+        // Подписка на изменения статуса
+        Mst.Client.Spawners.OnStatusChangedEvent += OnSpawnStatusChanged;
+    }
+});
+
+// Сервер
+SpawnTask task = Spawn(options, region);
+```
+
+### 출시를위한 스파이너 선택
+```csharp
+// Фильтрация спаунеров по региону
+var spawners = GetSpawnersInRegion(region);
+
+// Сортировка по доступным слотам
+var availableSpawners = spawners
+    .OrderByDescending(s => s.CalculateFreeSlotsCount())
+    .Where(s => s.CanSpawnAnotherProcess())
+    .ToList();
+
+// Выбор спаунера
+if (availableSpawners.Count > 0)
+{
+    return availableSpawners[0];
+}
+```
+
+### 스폰 프로세스 완료
+```csharp
+// На стороне процесса
+var finalizationData = new MstProperties();
+finalizationData.Set("roomId", 12345);
+finalizationData.Set("connectionAddress", "192.168.1.10:12345");
+
+// Отправка данных о завершении
+Mst.Client.Spawners.FinalizeSpawn(spawnTaskId, finalizationData);
+
+// На стороне клиента
+Mst.Client.Spawners.GetFinalizationData(spawnId, (successful, data) =>
+{
+    if (successful)
+    {
+        string connectionAddress = data.AsString("connectionAddress");
+        int roomId = data.AsInt("roomId");
+        
+        // Подключение к комнате
+        ConnectToRoom(connectionAddress, roomId);
+    }
+});
+```
+
+## 지역 사무소
+
+```csharp
+// Получение всех регионов
+List<RegionInfo> regions = spawnersModule.GetRegions();
+
+// Получение спаунеров в конкретном регионе
+List<RegisteredSpawner> regionalSpawners = spawnersModule.GetSpawnersInRegion("eu-west");
+
+// Создание спаунера в регионе
+var options = new SpawnerOptions { Region = "eu-west" };
+var spawner = spawnersModule.CreateSpawner(peer, options);
+```
+
+## 밸런싱 하중
+
+```csharp
+// Пример балансировки по наименее загруженным серверам
+public RegisteredSpawner GetLeastBusySpawner(string region)
+{
+    var spawners = GetSpawnersInRegion(region);
+    
+    // Если нет спаунеров в регионе, используем все доступные
+    if (spawners.Count == 0)
+        spawners = GetSpawners();
+    
+    // Сортировка по загруженности
+    return spawners
+        .OrderByDescending(s => s.CalculateFreeSlotsCount())
+        .FirstOrDefault(s => s.CanSpawnAnotherProcess());
+}
+
+// Расширенная логика выбора спаунера
+public RegisteredSpawner GetOptimalSpawner(MstProperties options)
+{
+    string region = options.AsString(Mst.Args.Names.RoomRegion, "");
+    string gameMode = options.AsString("gameMode", "");
+    
+    // Фильтрация по региону и игровому режиму
+    var filtered = spawnersList.Values
+        .Where(s => (string.IsNullOrEmpty(region) || s.Options.Region == region) &&
+                  (string.IsNullOrEmpty(gameMode) || 
+                   s.Options.CustomOptions.ContainsKey("gameModes") && 
+                   s.Options.CustomOptions["gameModes"].Contains(gameMode)))
+        .ToList();
+    
+    return filtered
+        .OrderByDescending(s => s.CalculateFreeSlotsCount())
+        .FirstOrDefault(s => s.CanSpawnAnotherProcess());
+}
+```
+
+## 실용적인 예
+
+### 시스템 설정 :
+```csharp
+// 1. Регистрация спаунеров
+RegisterSpawner("EU", "10.0.0.1", 10);
+RegisterSpawner("US", "10.0.1.1", 15);
+RegisterSpawner("ASIA", "10.0.2.1", 8);
+
+// 2. Клиентский запрос на создание игрового сервера
+var options = new MstProperties();
+options.Set(Mst.Args.Names.RoomName, "CustomGame");
+options.Set(Mst.Args.Names.RoomMaxPlayers, 16);
+options.Set(Mst.Args.Names.RoomRegion, "EU");
+options.Set("gameMode", "deathmatch");
+
+// 3. Обработка запроса, выбор спаунера и запуск процесса
+SpawnTask task = spawnersModule.Spawn(options, "EU");
+
+// 4. Клиент ожидает завершения процесса
+// 5. Созданный процесс регистрируется и отправляет данные для подключения
+```
+
+## 모범 사례
+
+1. ** 지역별 그룹 스파이너 ** 최적의 지연을위한
+2. ** 서버의 전력을 고려하여 각 스파이너마다 프로세스 한계 설정 **
+3. ** 유연한 튜닝 스패너에는 사용자 정의 옵션 사용 **
+4. ** 고장 공차 향상 ** - 스파이너를 사용할 수없는 경우 작업을 다른 지역으로 리디렉션하십시오.
+5. ** 좁은 장소를 감지하기 위해 스파이너의 작업량 **
+6. ** 작업에 대한 타임 아웃 추가 ** 멈추지 않도록 줄을 서십시오.

--- a/Docs/kr/Modules/WebServer.md
+++ b/Docs/kr/Modules/WebServer.md
@@ -1,1 +1,579 @@
-TODO: 한국어 번역
+# Master Server Toolkit - Web Server
+
+## 설명
+Webserver 모듈은 내장 된 HTTP 서버를 제공하여 웹 인터페이스, API 및 모니터링 시스템을 통해 게임 서버를 제어합니다.외부 서비스 및 관리자 패널 용 RESTFUL API를 만들 수 있습니다.
+
+## WebServerModule
+
+웹 서버 모듈의 주요 클래스.
+
+### 설정 :
+```csharp
+[Header("Http Server Settings")]
+[SerializeField] protected bool autostart = true;
+[SerializeField] protected string httpAddress = "127.0.0.1";
+[SerializeField] protected int httpPort = 5056;
+[SerializeField] protected string[] defaultIndexPage = new string[] { "index", "home" };
+
+[Header("User Credentials Settings")]
+[SerializeField] protected bool useCredentials = true;
+[SerializeField] protected string username = "admin";
+[SerializeField] protected string password = "admin";
+
+[Header("Assets")]
+[SerializeField] protected TextAsset startPage;
+```
+
+### 발사 및 중지 :
+```csharp
+// Инициализация с автозапуском
+public override void Initialize(IServer server)
+{
+    if (autostart)
+    {
+        Listen();
+    }
+}
+
+// Запуск вручную
+var webServer = Mst.Server.Modules.GetModule<WebServerModule>();
+webServer.Listen(); // Используя настройки по умолчанию
+
+// Запуск с указанием URL
+webServer.Listen("http://localhost:8080");
+
+// Остановка сервера
+webServer.Stop();
+```
+
+### 명령 줄 인수 :
+```bash
+--web-username "admin"    # Имя пользователя для доступа к веб-интерфейсу
+--web-password "secret"   # Пароль для доступа к веб-интерфейсу
+--web-port 8080           # Порт для HTTP сервера
+--web-address "0.0.0.0"   # Адрес для прослушивания (0.0.0.0 для всех интерфейсов)
+```
+
+## 핸들러 등록
+
+## http 메소드 (Get, Post, Put, Delete) :
+```csharp
+// GET запрос
+webServer.RegisterGetHandler("stats", GetStatisticsHandler);
+
+// POST запрос
+webServer.RegisterPostHandler("users/create", CreateUserHandler, true); // true - требует авторизацию
+
+// PUT запрос
+webServer.RegisterPutHandler("users/update", UpdateUserHandler, true);
+
+// DELETE запрос
+webServer.RegisterDeleteHandler("users/delete", DeleteUserHandler, true);
+
+// Пример обработчика
+private async Task<IHttpResult> GetStatisticsHandler(HttpListenerRequest request)
+{
+    var stats = new
+    {
+        playersOnline = 120,
+        roomsCount = 25,
+        serverUptime = "10 hours"
+    };
+    
+    return new JsonResult(stats);
+}
+```
+
+## 결과 http
+
+### 결과 유형 :
+```csharp
+// Текстовый ответ
+var stringResult = new StringResult("Hello, World!");
+stringResult.ContentType = "text/plain"; // по умолчанию
+
+// JSON ответ
+var jsonResult = new JsonResult(new { status = "ok", users = 5 });
+
+// Код состояния
+var badRequest = new BadRequest(); // 400
+var unauthorized = new Unauthorized(); // 401
+var notFound = new NotFound(); // 404
+var serverError = new InternalServerError("Database error"); // 500
+```
+
+### 현금 답변 :
+```csharp
+public class HtmlResult : HttpResult
+{
+    public string Html { get; set; }
+    
+    public HtmlResult(string html)
+    {
+        Html = html;
+        ContentType = "text/html";
+        StatusCode = 200;
+    }
+    
+    public override async Task ExecuteResultAsync(HttpListenerResponse response)
+    {
+        using (var writer = new StreamWriter(response.OutputStream))
+        {
+            await writer.WriteAsync(Html);
+        }
+    }
+}
+
+// Использование
+private async Task<IHttpResult> GetDashboardHandler(HttpListenerRequest request)
+{
+    string html = "<html><body><h1>Dashboard</h1></body></html>";
+    return new HtmlResult(html);
+}
+```
+
+## Web Controllers
+
+웹 컨트롤러를 사용하면 구조화 된 핸들러 그룹을 만들 수 있습니다.
+
+## 컨트롤러 생성 :
+```csharp
+public class UsersController : WebController
+{
+    public override void Initialize(WebServerModule server)
+    {
+        base.Initialize(server);
+        
+        // Настройка безопасности
+        UseCredentials = true;
+        
+        // Регистрация маршрутов
+        WebServer.RegisterGetHandler("users/list", GetUsersList);
+        WebServer.RegisterGetHandler("users/view", GetUserDetails);
+        WebServer.RegisterPostHandler("users/create", CreateUser, true);
+        WebServer.RegisterPutHandler("users/update", UpdateUser, true);
+        WebServer.RegisterDeleteHandler("users/delete", DeleteUser, true);
+    }
+    
+    private async Task<IHttpResult> GetUsersList(HttpListenerRequest request)
+    {
+        // Логика получения списка пользователей
+        var users = new[] 
+        { 
+            new { id = 1, name = "John" },
+            new { id = 2, name = "Alice" }
+        };
+        
+        return new JsonResult(users);
+    }
+    
+    private async Task<IHttpResult> GetUserDetails(HttpListenerRequest request)
+    {
+        // Получение параметров запроса
+        string id = request.QueryString["id"];
+        
+        if (string.IsNullOrEmpty(id))
+            return new BadRequest();
+        
+        // Логика получения данных пользователя
+        var user = new { id = int.Parse(id), name = "John", email = "john@example.com" };
+        
+        return new JsonResult(user);
+    }
+    
+    private async Task<IHttpResult> CreateUser(HttpListenerRequest request)
+    {
+        // Чтение тела запроса
+        using (var reader = new StreamReader(request.InputStream))
+        {
+            string body = await reader.ReadToEndAsync();
+            // Парсинг JSON и создание пользователя
+            
+            return new JsonResult(new { success = true, message = "User created" });
+        }
+    }
+    
+    // Другие методы...
+}
+```
+
+### 컨트롤러 추가 :
+```csharp
+// 1. Через добавление на GameObject
+gameObject.AddComponent<UsersController>();
+
+// 2. Или программно
+var controller = new UsersController();
+Controllers.TryAdd(controller.GetType(), controller);
+controller.Initialize(this);
+```
+
+## 빌드 -컨트롤러
+
+### InfoWebController:
+```csharp
+// Предоставляет информацию о сервере
+// GET /info - общая информация
+// GET /info/modules - список модулей
+// GET /info/connections - информация о подключениях
+```
+
+### NotificationWebController:
+```csharp
+// Отправка уведомлений через веб-интерфейс
+// POST /notifications/all - отправить всем
+// POST /notifications/room/{roomId} - отправить в комнату
+// POST /notifications/user/{userId} - отправить пользователю
+
+// Пример использования:
+// curl -X POST http://localhost:5056/notifications/all
+//   -u admin:admin
+//   -H "Content-Type: application/json"
+//   -d '{"message":"Server will restart in 5 minutes"}'
+```
+
+### AnalyticsWebController:
+```csharp
+// Получение аналитических данных
+// GET /analytics/users - статистика пользователей
+// GET /analytics/rooms - статистика комнат
+```
+
+## 요청 처리
+
+### 읽기 요청 매개 변수 :
+```csharp
+private async Task<IHttpResult> SearchHandler(HttpListenerRequest request)
+{
+    // Query параметры (?name=value)
+    string query = request.QueryString["q"];
+    string limit = request.QueryString["limit"] ?? "10";
+    
+    // Заголовки
+    string authorization = request.Headers["Authorization"];
+    string contentType = request.ContentType;
+    
+    // Cookies
+    Cookie sessionCookie = request.Cookies["session"];
+    
+    // URL параметры
+    string[] segments = request.Url.Segments;
+    
+    // Результат
+    return new JsonResult(new { 
+        query = query,
+        limit = int.Parse(limit),
+        results = new[] { "result1", "result2" }
+    });
+}
+```
+
+### 신체 읽기 :
+```csharp
+private async Task<IHttpResult> CreateItemHandler(HttpListenerRequest request)
+{
+    // Проверка Content-Type
+    if (!request.ContentType.Contains("application/json"))
+        return new BadRequest();
+    
+    // Чтение тела запроса
+    string body;
+    using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
+    {
+        body = await reader.ReadToEndAsync();
+    }
+    
+    try
+    {
+        // Десериализация JSON
+        var data = JsonUtility.FromJson<ItemData>(body);
+        
+        // Создание объекта
+        string itemId = Guid.NewGuid().ToString();
+        
+        return new JsonResult(new { 
+            success = true, 
+            id = itemId 
+        });
+    }
+    catch (Exception ex)
+    {
+        return new BadRequest();
+    }
+}
+
+[Serializable]
+public class ItemData
+{
+    public string name;
+    public int quantity;
+}
+```
+
+## 인증 및 승인
+
+### 기본 인증 설정 :
+```csharp
+// 1. В Inspector
+[SerializeField] protected bool useCredentials = true;
+[SerializeField] protected string username = "admin";
+[SerializeField] protected string password = "admin";
+
+// 2. В коде при регистрации обработчика
+// true - требуется авторизация, false - публичный доступ
+webServer.RegisterGetHandler("admin/stats", AdminStatsHandler, true);
+```
+
+### 카스트 승인 :
+```csharp
+public class CustomAuthController : WebController
+{
+    private Dictionary<string, string> apiKeys = new Dictionary<string, string>
+    {
+        { "client1", "key1" },
+        { "client2", "key2" }
+    };
+    
+    public override void Initialize(WebServerModule server)
+    {
+        base.Initialize(server);
+        
+        // Отключаем встроенную Basic Authentication
+        UseCredentials = false;
+        
+        WebServer.RegisterGetHandler("api/data", GetApiData);
+    }
+    
+    private async Task<IHttpResult> GetApiData(HttpListenerRequest request)
+    {
+        // Проверка API ключа
+        string apiKey = request.Headers["X-API-Key"];
+        
+        if (string.IsNullOrEmpty(apiKey) || !apiKeys.ContainsValue(apiKey))
+            return new Unauthorized();
+        
+        // Авторизованный доступ
+        return new JsonResult(new { data = "Secure API data" });
+    }
+}
+```
+
+## 웹 인터페이스를 만듭니다
+
+### 내장 -시작 페이지 :
+```csharp
+[Header("Assets")]
+[SerializeField] protected TextAsset startPage;
+
+// HTML страница с плейсхолдерами
+// #MST-TITLE# - будет заменено на "MST v.X.X.X"
+// #MST-GREETINGS# - будет заменено на "MST v.X.X.X"
+```
+
+### 생성 HTML 컨트롤러 :
+```csharp
+public class DashboardController : WebController
+{
+    [SerializeField] private TextAsset dashboardHtmlTemplate;
+    [SerializeField] private TextAsset loginHtmlTemplate;
+    
+    public override void Initialize(WebServerModule server)
+    {
+        base.Initialize(server);
+        
+        // Публичные страницы
+        WebServer.RegisterGetHandler("login", LoginPage, false);
+        
+        // Защищенные страницы
+        WebServer.RegisterGetHandler("dashboard", DashboardPage, true);
+        WebServer.RegisterGetHandler("dashboard/users", UsersPage, true);
+    }
+    
+    private async Task<IHttpResult> LoginPage(HttpListenerRequest request)
+    {
+        var result = new StringResult(loginHtmlTemplate.text);
+        result.ContentType = "text/html";
+        return result;
+    }
+    
+    private async Task<IHttpResult> DashboardPage(HttpListenerRequest request)
+    {
+        // Получение статистики
+        var playersCount = Mst.Server.ConnectionsCount;
+        var roomsCount = Mst.Server.Modules.GetModule<RoomsModule>()?.GetRooms().Count ?? 0;
+        
+        // Подстановка данных в шаблон
+        string html = dashboardHtmlTemplate.text
+            .Replace("{{PLAYERS_COUNT}}", playersCount.ToString())
+            .Replace("{{ROOMS_COUNT}}", roomsCount.ToString())
+            .Replace("{{SERVER_UPTIME}}", GetServerUptime());
+        
+        var result = new StringResult(html);
+        result.ContentType = "text/html";
+        return result;
+    }
+}
+```
+
+## 외부 서비스를위한 RESTFUL API
+
+### 게임 API의 예 :
+```csharp
+public class GameApiController : WebController
+{
+    private AuthModule authModule;
+    private ProfilesModule profilesModule;
+    
+    public override void Initialize(WebServerModule server)
+    {
+        base.Initialize(server);
+        
+        // Получение зависимостей
+        authModule = server.GetModule<AuthModule>();
+        profilesModule = server.GetModule<ProfilesModule>();
+        
+        // API маршруты
+        WebServer.RegisterGetHandler("api/players", GetPlayers, true);
+        WebServer.RegisterGetHandler("api/players/online", GetOnlinePlayers, true);
+        WebServer.RegisterGetHandler("api/player", GetPlayer, true);
+        WebServer.RegisterPostHandler("api/player/reward", AddReward, true);
+    }
+    
+    private async Task<IHttpResult> GetOnlinePlayers(HttpListenerRequest request)
+    {
+        var onlinePlayers = authModule.LoggedInUsers.Select(u => new {
+            id = u.UserId,
+            username = u.Username,
+            isGuest = u.IsGuest
+        }).ToList();
+        
+        return new JsonResult(onlinePlayers);
+    }
+    
+    private async Task<IHttpResult> AddReward(HttpListenerRequest request)
+    {
+        // Чтение тела запроса
+        using (var reader = new StreamReader(request.InputStream))
+        {
+            string body = await reader.ReadToEndAsync();
+            var data = JsonUtility.FromJson<RewardData>(body);
+            
+            // Поиск пользователя
+            var user = authModule.GetLoggedInUserById(data.userId);
+            
+            if (user == null)
+                return new NotFound();
+            
+            // Поиск профиля
+            if (!user.Peer.TryGetExtension(out ProfilePeerExtension profileExt))
+                return new NotFound();
+            
+            // Добавление валюты
+            if (profileExt.Profile.TryGet(ProfilePropertyOpCodes.currency, out ObservableDictionary currencies))
+            {
+                currencies.Set(data.currencyType, currencies.Get(data.currencyType, 0) + data.amount);
+                return new JsonResult(new { success = true });
+            }
+            else
+            {
+                return new InternalServerError("Currency property not found");
+            }
+        }
+    }
+    
+    [Serializable]
+    private class RewardData
+    {
+        public string userId;
+        public string currencyType;
+        public int amount;
+    }
+}
+```
+
+## 외부 시스템과의 통합
+
+### Webhuki (Webhooks) :
+```csharp
+// Отправка вебхука при событии в игре
+public class WebhookManager : MonoBehaviour
+{
+    [SerializeField] private string webhookUrl = "https://example.com/webhook";
+    
+    private AuthModule authModule;
+    
+    private void Start()
+    {
+        authModule = Mst.Server.Modules.GetModule<AuthModule>();
+        
+        // Подписка на события
+        authModule.OnUserLoggedInEvent += OnUserLoggedIn;
+        authModule.OnUserLoggedOutEvent += OnUserLoggedOut;
+    }
+    
+    private async void OnUserLoggedIn(IUserPeerExtension user)
+    {
+        var data = new WebhookData
+        {
+            eventType = "user.login",
+            userId = user.UserId,
+            username = user.Username,
+            timestamp = DateTime.UtcNow.ToString("o")
+        };
+        
+        await SendWebhookAsync(data);
+    }
+    
+    private async void OnUserLoggedOut(IUserPeerExtension user)
+    {
+        var data = new WebhookData
+        {
+            eventType = "user.logout",
+            userId = user.UserId,
+            username = user.Username,
+            timestamp = DateTime.UtcNow.ToString("o")
+        };
+        
+        await SendWebhookAsync(data);
+    }
+    
+    private async Task SendWebhookAsync(WebhookData data)
+    {
+        try
+        {
+            using (var client = new WebClient())
+            {
+                client.Headers[HttpRequestHeader.ContentType] = "application/json";
+                string json = JsonUtility.ToJson(data);
+                await client.UploadStringTaskAsync(webhookUrl, json);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Failed to send webhook: {ex.Message}");
+        }
+    }
+    
+    [Serializable]
+    private class WebhookData
+    {
+        public string eventType;
+        public string userId;
+        public string username;
+        public string timestamp;
+    }
+}
+```
+
+## 모범 사례
+
+1. ** 컨트롤러를 사용하여 논리를 구성 ** - 컨트롤러의 그룹 관련 핸들러
+2. ** 관리자 기능에 대한 권한 켜기 ** - 보호 된 경로의 경우 usecredentials = true`를 사용하십시오.
+3. ** 프로세스 오류 및 올바른 HTTP 코드를 반환 ** - 결과의 결과를 사용하십시오 (Badrequest, NotFound 등).
+4. ** 입력 데이터를 Valide ** - 사용하기 전에 항상 쿼리 매개 변수와 본문을 확인하십시오.
+5. ** 문서 생성 API ** - 사용 가능한 경로, 매개 변수 및 결과를 설명
+6. ** 별도의 읽기 및 변경 ** - 읽기, 게시/풋/삭제에 사용하기 시작하십시오.
+7. ** 필요한 경우 CORS 설정 ** - 외부 웹 응용 프로그램에서 액세스하기 위해
+8. ** IP의 액세스 제한 ** - 비판적으로 중요한 API의 경우
+9. ** JSON을 사용하여 데이터 교환 ** - 다른 형식보다 선호됩니다.
+10. ** API의 추적 통계 개선 ** - 사용 및 성능 모니터링을위한

--- a/Docs/kr/Modules/WorldRooms.md
+++ b/Docs/kr/Modules/WorldRooms.md
@@ -1,1 +1,309 @@
-TODO: 한국어 번역
+# Master Server Toolkit - World Rooms
+
+## 설명
+Worldroom 모듈은 기본 룸 모듈의 기능을 확장하여 오픈 월드에서 지속적인 게임 영역 (위치)을 생성하며 자동으로 시작하고 관리 할 수 ​​있습니다.
+
+## 주요 구성 요소
+
+### WorldRoomsModule
+```csharp
+// Настройки
+[Header("Zones Settings"), SerializeField]
+private string[] zoneScenes; // Сцены зон, которые будут автоматически запущены
+
+// Зависимости
+protected SpawnersModule spawnersModule; // Для запуска серверов зон
+```
+
+## 세계 구역의 자동 생성
+
+```csharp
+// При регистрации спаунера автоматически запускаются все зоны
+private async void Spawners_OnSpawnerRegisteredEvent(RegisteredSpawner spawner)
+{
+    await Task.Delay(100);
+
+    foreach (string zoneScene in zoneScenes)
+    {
+        spawnersModule.Spawn(SpawnerProperties(zoneScene)).WhenDone(task =>
+        {
+            logger.Info($"{zoneScene} zone status is: {task.Status}");
+        });
+    }
+}
+```
+
+## 영역의 속성 설정
+
+```csharp
+// Создание настроек для запуска зоны на спаунере
+protected virtual MstProperties SpawnerProperties(string zoneId)
+{
+    var properties = new MstProperties();
+    properties.Set(Mst.Args.Names.RoomName, zoneId);        // Имя комнаты
+    properties.Set(Mst.Args.Names.RoomOnlineScene, zoneId); // Имя сцены
+    properties.Set(Mst.Args.Names.RoomIsPrivate, true);     // Приватная комната
+    properties.Set(MstDictKeys.WORLD_ZONE, zoneId);         // Маркер зоны мира
+    
+    return properties;
+}
+```
+
+## 영역에 대한 정보를 얻습니다
+
+```csharp
+// На сервере - поиск комнаты зоны по ID
+RegisteredRoom zoneRoom = roomsList.Values
+    .Where(r => r.Options.CustomOptions.AsString(MstDictKeys.WORLD_ZONE) == zoneId)
+    .FirstOrDefault();
+
+// Формирование информации о зоне для отправки клиенту
+var game = new GameInfoPacket
+{
+    Id = zoneRoom.RoomId,
+    Address = zoneRoom.Options.RoomIp + ":" + zoneRoom.Options.RoomPort,
+    MaxPlayers = zoneRoom.Options.MaxConnections,
+    Name = zoneRoom.Options.Name,
+    OnlinePlayers = zoneRoom.OnlineCount,
+    Properties = GetPublicRoomOptions(message.Peer, zoneRoom, null),
+    IsPasswordProtected = !string.IsNullOrEmpty(zoneRoom.Options.Password),
+    Type = GameInfoType.Room,
+    Region = zoneRoom.Options.Region
+};
+```
+
+## 클라이언트 영역에 대한 정보 요청
+
+```csharp
+// Запрос информации о зоне по ее ID
+Mst.Client.Connection.SendMessage(MstOpCodes.GetZoneRoomInfo, "Forest", (status, response) =>
+{
+    if (status == ResponseStatus.Success)
+    {
+        // Получение данных о зоне
+        var zoneInfo = response.AsPacket<GameInfoPacket>();
+        
+        // Подключение к серверу зоны
+        string address = zoneInfo.Address;
+        int roomId = zoneInfo.Id;
+        
+        ConnectToZone(address, roomId);
+    }
+    else
+    {
+        Debug.LogError("Failed to get zone room info");
+    }
+});
+```
+
+## 영역 간 전환
+
+```csharp
+// Клиентский код для перехода между зонами
+public void RequestZoneTransition(string targetZoneId, Vector3 spawnPosition)
+{
+    // 1. Запрос информации о целевой зоне
+    Mst.Client.Connection.SendMessage(MstOpCodes.GetZoneRoomInfo, targetZoneId, (status, response) =>
+    {
+        if (status == ResponseStatus.Success)
+        {
+            // 2. Получение информации о зоне
+            var zoneInfo = response.AsPacket<GameInfoPacket>();
+            
+            // 3. Сохранение позиции появления для новой зоны
+            PlayerPrefs.SetFloat("SpawnPosX", spawnPosition.x);
+            PlayerPrefs.SetFloat("SpawnPosY", spawnPosition.y);
+            PlayerPrefs.SetFloat("SpawnPosZ", spawnPosition.z);
+            
+            // 4. Отключение от текущей зоны
+            Mst.Client.Connection.Disconnect();
+            
+            // 5. Подключение к новой зоне
+            ConnectToZone(zoneInfo.Address, zoneInfo.Id);
+        }
+    });
+}
+
+// Подключение к серверу зоны
+private void ConnectToZone(string address, int roomId)
+{
+    // Разбор адреса в формате "ip:port"
+    string[] addressParts = address.Split(':');
+    string ip = addressParts[0];
+    int port = int.Parse(addressParts[1]);
+    
+    // Подключение к серверу
+    Mst.Client.Connection.Connect(ip, port, (successful, connectedPeer) =>
+    {
+        if (successful)
+        {
+            Debug.Log($"Connected to zone server: {address}");
+            
+            // Присоединение к комнате после подключения к серверу
+            Mst.Client.Rooms.JoinRoom(roomId, "", (successfulJoin, roomAccess) =>
+            {
+                if (successfulJoin)
+                {
+                    Debug.Log($"Joined zone room: {roomId}");
+                }
+            });
+        }
+    });
+}
+```
+
+## 페르시아 세계와의 통합
+
+```csharp
+// Пример кода сервера зоны для обработки подключения игрока
+protected override void OnPlayerJoinedRoom(RoomPlayer player)
+{
+    base.OnPlayerJoinedRoom(player);
+    
+    // Получение расширения пользователя
+    var userExt = player.GetExtension<IUserPeerExtension>();
+    if (userExt != null)
+    {
+        // Загрузка данных игрока для текущей зоны
+        LoadPlayerZoneData(userExt.UserId);
+        
+        // Отправка данных о других игроках в зоне
+        SendZonePlayersData(player);
+    }
+}
+
+// Загрузка данных игрока для конкретной зоны
+private void LoadPlayerZoneData(string userId)
+{
+    // Получение данных из профиля или базы данных
+    var zoneId = gameObject.scene.name;
+    var zoneDataKey = $"zonedata_{zoneId}_{userId}";
+    
+    // Запрос данных из профиля
+    Mst.Server.Profiles.GetProfileValues(userId, new string[] { zoneDataKey }, (success, data) =>
+    {
+        if (success && data.Has(zoneDataKey))
+        {
+            // Разбор данных зоны (позиция, инвентарь и т.д.)
+            var zoneData = data.AsString(zoneDataKey);
+            // Применение данных к игроку
+            ApplyZoneDataToPlayer(userId, zoneData);
+        }
+        else
+        {
+            // Использование данных по умолчанию для новых игроков в этой зоне
+            ApplyDefaultZoneData(userId);
+        }
+    });
+}
+```
+
+## 영역을 떠날 때 데이터 조건
+
+```csharp
+// Сервер зоны: обработка выхода игрока из зоны
+protected override void OnPlayerLeftRoom(RoomPlayer player)
+{
+    base.OnPlayerLeftRoom(player);
+    
+    // Получение расширения пользователя
+    var userExt = player.GetExtension<IUserPeerExtension>();
+    if (userExt != null)
+    {
+        // Сохранение данных игрока для текущей зоны
+        SavePlayerZoneData(userExt.UserId);
+    }
+}
+
+// Сохранение данных игрока для конкретной зоны
+private void SavePlayerZoneData(string userId)
+{
+    // Сбор данных игрока (позиция, инвентарь и т.д.)
+    string zoneData = GenerateZoneDataForPlayer(userId);
+    
+    // Формирование ключа зоны
+    var zoneId = gameObject.scene.name;
+    var zoneDataKey = $"zonedata_{zoneId}_{userId}";
+    
+    // Сохранение в профиль
+    var data = new MstProperties();
+    data.Set(zoneDataKey, zoneData);
+    
+    Mst.Server.Profiles.SetProfileValues(userId, data);
+}
+```
+
+## 사용의 예
+
+### 영역 간의 전환 설정
+```csharp
+// Зона "Лес" соединяется с зоной "Пещера"
+public class ZoneTransition : MonoBehaviour
+{
+    [SerializeField] private string targetZoneId = "Cave";
+    [SerializeField] private Vector3 spawnPosition = new Vector3(10, 0, 10);
+    
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            // Отправка запроса на переход в другую зону
+            var zoneManager = FindObjectOfType<WorldZoneManager>();
+            zoneManager.RequestZoneTransition(targetZoneId, spawnPosition);
+        }
+    }
+}
+```
+
+### 구역의 글로벌 이벤트
+```csharp
+// Система глобальных событий для синхронизации между зонами
+public class GlobalEventsManager : MonoBehaviour
+{
+    // Отправка глобального события всем зонам
+    public void BroadcastGlobalEvent(string eventType, MstProperties eventData)
+    {
+        // Отправка события на мастер сервер
+        var data = new MstProperties();
+        data.Set("type", eventType);
+        data.Set("data", eventData.ToJson());
+        
+        Mst.Client.Connection.SendMessage(MstOpCodes.GlobalZoneEvent, data);
+    }
+}
+
+// На мастер сервере
+private Task GlobalZoneEventHandler(IIncomingMessage message)
+{
+    try
+    {
+        var data = MstProperties.FromBytes(message.AsBytes());
+        string eventType = data.AsString("type");
+        string eventData = data.AsString("data");
+        
+        // Рассылка всем зонам
+        foreach (var room in roomsList.Values)
+        {
+            if (room.Options.CustomOptions.Has(MstDictKeys.WORLD_ZONE))
+            {
+                room.SendMessage(MstOpCodes.GlobalZoneEvent, data.ToBytes());
+            }
+        }
+        
+        return Task.CompletedTask;
+    }
+    catch (System.Exception ex)
+    {
+        return Task.FromException(ex);
+    }
+}
+```
+
+## 모범 사례
+
+1. ** 구역 디비전 **를 사용하여 서버의 부하를 줄입니다.
+2. ** 데이터 저장 ** 영역 사이를 건너면
+3. ** 데이터 전송 최적화 ** - 필요한 정보 만 보내기
+4. ** 매끄러운 전환 개선 ** 화면을 로딩하는 영역간에
+5. ** 영역 간의 동기화를 위해 전체 이벤트 시스템을 사용하십시오 **
+6. ** 공유 책임 ** 영역 서버와 마스터 서버간에


### PR DESCRIPTION
## Summary
- translate Achievements docs to Korean
- translate AnalyticsModule docs to Korean
- translate Authentication docs to Korean
- translate Censor docs to Korean
- translate Chat docs to Korean
- translate Lobbies docs to Korean
- translate Matchmaker docs to Korean
- translate Ping docs to Korean
- translate Profiles docs to Korean
- translate QuestsModule docs to Korean
- translate Rooms docs to Korean
- translate Spawner docs to Korean
- translate WebServer docs to Korean
- translate WorldRooms docs to Korean

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6854a3adffe08328959eed6cbe989a97